### PR TITLE
fix_read_file_and_iterative_loop

### DIFF
--- a/examples/ScatterRun/ScatterEstimation.par
+++ b/examples/ScatterRun/ScatterEstimation.par
@@ -46,11 +46,11 @@ mask projdata filename := ./produced_data/mask_projdata.hs
 recompute mask image := 1
 mask attenuation image filename := ./produced_data/mask.hv
 
-mask max threshold := 0.001
-mask add scalar := -0.00099 
-mask min threshold := 0.0
-mask times scalar := 100002
-mask postfilter filename := ./par_files/postfilter_Gaussian.par
+mask image max threshold  := 0.001
+mask image additive scalarr := -0.00099 
+mask image min threshold := 0.0
+mask image times scalar := 100002
+mask image postfilter filename := ./par_files/postfilter_Gaussian.par
 ;End of Mask
 
 ;Parameter file for the tail fitting of the mask image.
@@ -65,12 +65,12 @@ export 2d projdata := 1
 scatter simulation parameters file := ./par_files/scatter_simulation.par 
 
 ; Over-ride the values set in the scatter simulation parameteres file
-over-ride scanner template := 1
-over-ride initial activity image := 1
-over-ride density image := 1
-over-ride density image for scatter points := 0
+override scanner template := 1
+override initial activity image := 1
+override density image := 1
+override density image for scatter points := 0
 
-reconstruction template file := ./par_files/run_reconstruction.par 
+reconstruction parameter template file := ./par_files/run_reconstruction.par 
 
 ;
 ; This is the number of times which the Scatter Estimation will
@@ -89,8 +89,8 @@ output scatter estimate name prefix := ./produced_data/total_back
 ; If provided it will be given to the ScatterSimulation 
 ; subsampled attenuation imagw filename := sub_atten.hv
 
-max scale value := 2 ;10
-min scale value := 0.4 ;0.1
+maximum scale value := 2 ;10
+minimum scale value := 0.4 ;0.1
 
 ;Upsample and fit 
 ; defaults to 3.

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -721,7 +721,7 @@ Scanner::operator ==(const Scanner& scanner) const
 if (!close_enough(energy_resolution, scanner.energy_resolution) &&
       !close_enough(reference_energy, scanner.reference_energy))
     warning("The energy resolution of the two scanners is different. \n"
-            " %d opposed to %d"
+            " %f opposed to %f"
             "This only affects scatter simulation. \n", energy_resolution, scanner.energy_resolution);
 
   return

--- a/src/scatter_buildblock/ScatterEstimation.cxx
+++ b/src/scatter_buildblock/ScatterEstimation.cxx
@@ -952,9 +952,10 @@ process_data()
     //
     info("ScatterEstimation: Begin the estimation process...");
     for (int i_scat_iter = 1;
-         i_scat_iter < this->num_scatter_iterations;
+         i_scat_iter <= this->num_scatter_iterations;
          i_scat_iter++)
     {
+
 
         if ( this->do_average_at_2)
         {

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -126,6 +126,7 @@ process_data()
                     this->proj_data_info_cyl_noarc_cor_sptr->get_num_axial_poss(vs_num.segment_num()) *
                     this->proj_data_info_cyl_noarc_cor_sptr->get_num_tangential_poss();
             info(boost::format("ScatterSimulator: %d / %d") % bin_counter% total_bins);
+
         }
     }
 
@@ -136,6 +137,7 @@ process_data()
         return Succeeded::no;
     }
 
+    std::cerr << "TOTAL SCATTER:= " << total_scatter << '\n';
     return Succeeded::yes;
 }
 
@@ -457,21 +459,20 @@ set_output_proj_data(const std::string& filename)
     {
         error("Template ProjData has not been set. Abord.");
     }
-
     this->output_proj_data_filename = filename;
-
     if (is_null_ptr(this->template_exam_info_sptr))
     {
         shared_ptr<ExamInfo> exam_info_sptr(new ExamInfo);
         this->output_proj_data_sptr.reset(new ProjDataInterfile(exam_info_sptr,
                                                                 this->proj_data_info_cyl_noarc_cor_sptr->create_shared_clone(),
-                                                                this->output_proj_data_filename));
+                                                                this->output_proj_data_filename,std::ios::in | std::ios::out | std::ios::trunc));
     }
     else
         this->output_proj_data_sptr.reset(new ProjDataInterfile(this->template_exam_info_sptr,
                                                                 this->proj_data_info_cyl_noarc_cor_sptr->create_shared_clone(),
-                                                                this->output_proj_data_filename));
+                                                                this->output_proj_data_filename,std::ios::in | std::ios::out | std::ios::trunc));
 }
+
 
 void
 ScatterSimulation::


### PR DESCRIPTION
Hi Nikos,
I changed 3 stuff:

1) there was a problem with the warning for the energy resolution values because it was %d instead of %f.

2) The loop over the number of scatter iterations was doing one iteration less than the one set from the parameter file.

3)If the output of the scatter simulation was specified in the scatter simulation parameter, the code writes it in a file, that couldn't be then read during the scatter estimation process, because it was write only.