### PR TITLE
Renaming ViewSegmentNumbers to ViewSegmentTOFNumbers and use TOF pos number from class throughout STIR

### DIFF
--- a/recon_test_pack/run_test_time_of_flight.sh
+++ b/recon_test_pack/run_test_time_of_flight.sh
@@ -20,8 +20,6 @@
 # Author Nikos Efthimiou
 # 
 
-export PATH=/Users/roberttwyman/bin/STIR/devel/TOF/install/bin:${PATH}
-
 # Scripts should exit with error code when a test fails:
 if [ -n "$TRAVIS" ]; then
     # The code runs inside Travis

--- a/recon_test_pack/run_test_time_of_flight.sh
+++ b/recon_test_pack/run_test_time_of_flight.sh
@@ -20,6 +20,8 @@
 # Author Nikos Efthimiou
 # 
 
+export PATH=/Users/roberttwyman/bin/STIR/devel/TOF/install/bin:${PATH}
+
 # Scripts should exit with error code when a test fails:
 if [ -n "$TRAVIS" ]; then
     # The code runs inside Travis

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -313,7 +313,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
 #endif
         {
           viewgrams =
-            proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);   
+            proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr, 0);
         }
 
         if (do_arc_correction)

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -313,7 +313,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
 #endif
         {
           viewgrams =
-            proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr, 0);
+            proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);
         }
 
         if (do_arc_correction)

--- a/src/analytic/FBP2D/FBP2DReconstruction.cxx
+++ b/src/analytic/FBP2D/FBP2DReconstruction.cxx
@@ -296,7 +296,7 @@ actual_reconstruct(shared_ptr<DiscretisedDensity<3,float> > const & density_ptr)
 #endif
     for (int view_num=proj_data_ptr->get_min_view_num(); view_num <= proj_data_ptr->get_max_view_num(); ++view_num) 
       {         
-        const ViewSegmentNumbers vs_num(view_num, 0);
+        const ViewSegmentTOFNumbers vs_num(view_num, 0);
     
 #ifndef NDEBUG
 #ifdef STIR_OPENMP

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -694,7 +694,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
       full_log << "\n  - Getting related viewgrams"  << endl;
  
       RelatedViewgrams<float> viewgrams = 
-	proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);
+	proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr, 0);
         
       do_process_viewgrams(
 			   viewgrams,

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -666,7 +666,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
     const int orig_max_axial_pos_num = proj_data_ptr->get_max_axial_pos_num(seg_num);
             
     for (int view_num=proj_data_ptr->get_min_view_num(); view_num <= proj_data_ptr->get_max_view_num(); ++view_num) {         
-      const ViewSegmentNumbers vs_num(view_num, seg_num);
+      const ViewSegmentTOFNumbers vs_num(view_num, seg_num);
       if (!symmetries_sptr->is_basic(vs_num))
 	continue;
 

--- a/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
+++ b/src/analytic/FBP3DRP/FBP3DRPReconstruction.cxx
@@ -694,7 +694,7 @@ void FBP3DRPReconstruction::do_3D_Reconstruction(
       full_log << "\n  - Getting related viewgrams"  << endl;
  
       RelatedViewgrams<float> viewgrams = 
-	proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr, 0);
+	proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);
         
       do_process_viewgrams(
 			   viewgrams,

--- a/src/buildblock/ArcCorrection.cxx
+++ b/src/buildblock/ArcCorrection.cxx
@@ -301,7 +301,7 @@ do_arc_correction(const RelatedViewgrams<float>& in) const
 {
   RelatedViewgrams<float> out =
     _arc_corr_proj_data_info_sptr->get_empty_related_viewgrams(in.get_basic_view_segment_num(),
-							       in.get_symmetries_sptr(), false);
+							       in.get_symmetries_sptr());
   do_arc_correction(out, in);
   return out;
 }

--- a/src/buildblock/ArcCorrection.cxx
+++ b/src/buildblock/ArcCorrection.cxx
@@ -301,7 +301,7 @@ do_arc_correction(const RelatedViewgrams<float>& in) const
 {
   RelatedViewgrams<float> out =
     _arc_corr_proj_data_info_sptr->get_empty_related_viewgrams(in.get_basic_view_segment_num(),
-							       in.get_symmetries_sptr(), false, in.get_basic_timing_pos_num());
+							       in.get_symmetries_sptr(), false);
   do_arc_correction(out, in);
   return out;
 }

--- a/src/buildblock/DataSymmetriesForViewSegmentNumbers.cxx
+++ b/src/buildblock/DataSymmetriesForViewSegmentNumbers.cxx
@@ -17,7 +17,7 @@
 */
 
 #include "stir/DataSymmetriesForViewSegmentNumbers.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include <typeinfo>
 
 using std::vector;
@@ -57,18 +57,18 @@ operator !=(const root_type& that) const
 
 
 int
-DataSymmetriesForViewSegmentNumbers::num_related_view_segment_numbers(const ViewSegmentNumbers& vs) const
+DataSymmetriesForViewSegmentNumbers::num_related_view_segment_numbers(const ViewSegmentTOFNumbers& vs) const
 {
-  vector<ViewSegmentNumbers> rel_vs;
+  vector<ViewSegmentTOFNumbers> rel_vs;
   get_related_view_segment_numbers(rel_vs, vs);
   return static_cast<int>(rel_vs.size());
 }
 
 bool
 DataSymmetriesForViewSegmentNumbers::
-is_basic(const ViewSegmentNumbers& v_s) const
+is_basic(const ViewSegmentTOFNumbers& v_s) const
 {
-  ViewSegmentNumbers copy = v_s;
+  ViewSegmentTOFNumbers copy = v_s;
   return !find_basic_view_segment_numbers(copy);
 }
 

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -267,14 +267,11 @@ ProjData::get_empty_segment_by_view(const int segment_num,
 }
 
 RelatedViewgrams<float> 
-ProjData::get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segmnet_num,
-                   //const int view_num, const int segment_num,
-		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
-		   const bool make_num_tangential_poss_odd) const
+ProjData::get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segment_num,
+                                      const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
+                                      const bool make_num_tangential_poss_odd) const
 {
-  return
-          proj_data_info_sptr->get_empty_related_viewgrams(view_segmnet_num, symmetries_used,
-                                                           make_num_tangential_poss_odd);
+  return proj_data_info_sptr->get_empty_related_viewgrams(view_segment_num, symmetries_used, make_num_tangential_poss_odd);
 }
 
 

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -270,11 +270,11 @@ RelatedViewgrams<float>
 ProjData::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segmnet_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
-		   const bool make_num_tangential_poss_odd,
-		   const int timing_pos) const
+		   const bool make_num_tangential_poss_odd) const
 {
   return
-    proj_data_info_sptr->get_empty_related_viewgrams(view_segmnet_num, symmetries_used, make_num_tangential_poss_odd, timing_pos);
+          proj_data_info_sptr->get_empty_related_viewgrams(view_segmnet_num, symmetries_used,
+                                                           make_num_tangential_poss_odd);
 }
 
 
@@ -282,13 +282,12 @@ RelatedViewgrams<float>
 ProjData::get_related_viewgrams(const ViewSegmentNumbers& view_segment_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
-		   const bool make_num_bins_odd,
-		   const int timing_pos) const
+		   const bool make_num_bins_odd) const
 {
   vector<ViewSegmentNumbers> pairs;
   symmetries_used->get_related_view_segment_numbers(
     pairs, 
-    ViewSegmentNumbers(view_segment_num.view_num(),view_segment_num.segment_num())
+    ViewSegmentNumbers(view_segment_num.view_num(),view_segment_num.segment_num(), view_segment_num.tof_pos_num())
     );
 
   vector<Viewgram<float> > viewgrams;
@@ -298,7 +297,7 @@ ProjData::get_related_viewgrams(const ViewSegmentNumbers& view_segment_num,
   {
     // TODO optimise to get shared proj_data_info_ptr
     viewgrams.push_back(get_viewgram(pairs[i].view_num(),
-                                          pairs[i].segment_num(), make_num_bins_odd,timing_pos));
+                                          pairs[i].segment_num(), make_num_bins_odd, pairs[i].tof_pos_num()));
   }
 
   return RelatedViewgrams<float>(viewgrams, symmetries_used);

--- a/src/buildblock/ProjData.cxx
+++ b/src/buildblock/ProjData.cxx
@@ -51,7 +51,7 @@
 #include "stir/IO/GEHDF5Wrapper.h"
 #endif
 #include "stir/IO/stir_ecat7.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/is_null_ptr.h"
 #include <cstring>
 #include <fstream>
@@ -267,7 +267,7 @@ ProjData::get_empty_segment_by_view(const int segment_num,
 }
 
 RelatedViewgrams<float> 
-ProjData::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segmnet_num,
+ProjData::get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segmnet_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
 		   const bool make_num_tangential_poss_odd) const
@@ -279,15 +279,15 @@ ProjData::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segmnet_num
 
 
 RelatedViewgrams<float> 
-ProjData::get_related_viewgrams(const ViewSegmentNumbers& view_segment_num,
+ProjData::get_related_viewgrams(const ViewSegmentTOFNumbers& view_segment_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
 		   const bool make_num_bins_odd) const
 {
-  vector<ViewSegmentNumbers> pairs;
+  vector<ViewSegmentTOFNumbers> pairs;
   symmetries_used->get_related_view_segment_numbers(
     pairs, 
-    ViewSegmentNumbers(view_segment_num.view_num(),view_segment_num.segment_num(), view_segment_num.tof_pos_num())
+    ViewSegmentTOFNumbers(view_segment_num.view_num(),view_segment_num.segment_num(), view_segment_num.tof_pos_num())
     );
 
   vector<Viewgram<float> > viewgrams;

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -33,7 +33,7 @@
 #include "stir/SegmentBySinogram.h"
 #include "stir/SegmentByView.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/Coordinate2D.h"
 #include "stir/Coordinate3D.h"
 #include "stir/IndexRange2D.h"
@@ -432,15 +432,15 @@ ProjDataInfo::get_empty_segment_by_view(const int segment_num,
 }
 
 RelatedViewgrams<float> 
-ProjDataInfo::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segment_num,
+ProjDataInfo::get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segment_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
 		   const bool make_num_tangential_poss_odd) const
 {
-  vector<ViewSegmentNumbers> pairs;
+  vector<ViewSegmentTOFNumbers> pairs;
   symmetries_used->get_related_view_segment_numbers(
                                                     pairs, 
-                                                    ViewSegmentNumbers(view_segment_num.view_num(),view_segment_num.segment_num())
+                                                    ViewSegmentTOFNumbers(view_segment_num.view_num(),view_segment_num.segment_num())
     );
 
   vector<Viewgram<float> > viewgrams;

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -435,8 +435,7 @@ RelatedViewgrams<float>
 ProjDataInfo::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segment_num,
                    //const int view_num, const int segment_num,
 		   const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_used,
-		   const bool make_num_tangential_poss_odd,
-		   const int timing_pos_num) const
+		   const bool make_num_tangential_poss_odd) const
 {
   vector<ViewSegmentNumbers> pairs;
   symmetries_used->get_related_view_segment_numbers(
@@ -453,7 +452,7 @@ ProjDataInfo::get_empty_related_viewgrams(const ViewSegmentNumbers& view_segment
     viewgrams.push_back(get_empty_viewgram(pairs[i].view_num(),
                                           pairs[i].segment_num(),
 										  make_num_tangential_poss_odd,
-										  timing_pos_num));
+										  pairs[i].tof_pos_num()));
   }
 
   return RelatedViewgrams<float>(viewgrams, symmetries_used);

--- a/src/buildblock/ProjDataInfo.cxx
+++ b/src/buildblock/ProjDataInfo.cxx
@@ -438,10 +438,7 @@ ProjDataInfo::get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segm
 		   const bool make_num_tangential_poss_odd) const
 {
   vector<ViewSegmentTOFNumbers> pairs;
-  symmetries_used->get_related_view_segment_numbers(
-                                                    pairs, 
-                                                    ViewSegmentTOFNumbers(view_segment_num.view_num(),view_segment_num.segment_num())
-    );
+  symmetries_used->get_related_view_segment_numbers(pairs, view_segment_num);
 
   vector<Viewgram<float> > viewgrams;
   viewgrams.reserve(pairs.size());

--- a/src/buildblock/RelatedViewgrams.cxx
+++ b/src/buildblock/RelatedViewgrams.cxx
@@ -45,10 +45,10 @@ void RelatedViewgrams<elemT>::debug_check_state() const
   if (viewgrams.size() == 0)
     return;
 
-  vector<ViewSegmentNumbers> pairs;
+  vector<ViewSegmentTOFNumbers> pairs;
   symmetries_used->get_related_view_segment_numbers(
     pairs, 
-    ViewSegmentNumbers(
+    ViewSegmentTOFNumbers(
        viewgrams[0].get_view_num(),
        viewgrams[0].get_segment_num()
 	) );

--- a/src/buildblock/zoom.cxx
+++ b/src/buildblock/zoom.cxx
@@ -127,7 +127,7 @@ zoom_viewgrams (RelatedViewgrams<float>& in_viewgrams,
     out_viewgrams = 
     new_proj_data_info_arccorr_sptr->
       get_empty_related_viewgrams(in_viewgrams.get_basic_view_segment_num(),
-				  symmetries_sptr,false);
+				  symmetries_sptr);
 
   {
     RelatedViewgrams<float>::iterator out_iter = out_viewgrams.begin();

--- a/src/buildblock/zoom.cxx
+++ b/src/buildblock/zoom.cxx
@@ -127,7 +127,7 @@ zoom_viewgrams (RelatedViewgrams<float>& in_viewgrams,
     out_viewgrams = 
     new_proj_data_info_arccorr_sptr->
       get_empty_related_viewgrams(in_viewgrams.get_basic_view_segment_num(),
-				  symmetries_sptr,false,in_viewgrams.get_basic_timing_pos_num());
+				  symmetries_sptr,false);
 
   {
     RelatedViewgrams<float>::iterator out_iter = out_viewgrams.begin();

--- a/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationFromML2D.cxx
@@ -19,7 +19,7 @@
 
 #include "stir_experimental/recon_buildblock/BinNormalisationFromML2D.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/Succeeded.h"
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir_experimental/ML_norm.h"

--- a/src/experimental/recon_buildblock/BinNormalisationSinogramRescaling.cxx
+++ b/src/experimental/recon_buildblock/BinNormalisationSinogramRescaling.cxx
@@ -17,7 +17,7 @@
 #include "stir_experimental/recon_buildblock/BinNormalisationSinogramRescaling.h"
 #include "stir/shared_ptr.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"
 #include "stir/stream.h"

--- a/src/experimental/utilities/interpolate_blocks.cxx
+++ b/src/experimental/utilities/interpolate_blocks.cxx
@@ -19,7 +19,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/Bin.h"
 #include "stir/Viewgram.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/utilities.h"
 #include "stir/Succeeded.h"
 #include "stir/ProjDataInterfile.h"

--- a/src/experimental/utilities/set_blocks_to_value.cxx
+++ b/src/experimental/utilities/set_blocks_to_value.cxx
@@ -18,7 +18,7 @@
 #include "stir/ProjDataInfoCylindricalNoArcCorr.h"
 #include "stir/Bin.h"
 #include "stir/Viewgram.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/utilities.h"
 #include "stir/Succeeded.h"
 #include "stir/ProjDataInterfile.h"

--- a/src/include/stir/DataSymmetriesForViewSegmentNumbers.h
+++ b/src/include/stir/DataSymmetriesForViewSegmentNumbers.h
@@ -27,7 +27,7 @@
 
 START_NAMESPACE_STIR
 
-class ViewSegmentNumbers;
+class ViewSegmentTOFNumbers;
 
 #if 0
 class ViewSegmentIndexRange;
@@ -37,14 +37,14 @@ class ViewSegmentIndexRange;
 /*!
   \ingroup projdata
   \brief A class for encoding/finding symmetries. Works only on
-  ViewSegmentNumbers (instead of Bin).
+  ViewSegmentTOFNumbers (instead of Bin).
 
   This class (mainly used in RelatedViewgrams and the projectors)
   is useful to store and use all information on symmetries
   common between the image representation and the projection data.
 
-  The class mainly defines members to find \c basic ViewSegmentNumbers. These form a 
-  'basis' for all ViewSegmentNumbers in the sense that all ViewSegmentNumbers
+  The class mainly defines members to find \c basic ViewSegmentTOFNumbers. These form a
+  'basis' for all ViewSegmentTOFNumbers in the sense that all ViewSegmentTOFNumbers
   can be obtained by using symmetry operations on the 'basic' ones.
 */
 class DataSymmetriesForViewSegmentNumbers
@@ -72,13 +72,13 @@ public:
 
   //! fills in a vector with all the view/segments that are related to 'v_s' (including itself)
   virtual void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers& v_s) const = 0;
+    get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>&, const ViewSegmentTOFNumbers& v_s) const = 0;
 
   //! returns the number of view_segment_numbers related to 'v_s'
   /*! The default implementation is in terms of get_related_view_segment_numbers, which will be 
       slow of course */
   virtual int
-    num_related_view_segment_numbers(const ViewSegmentNumbers& v_s) const;
+    num_related_view_segment_numbers(const ViewSegmentTOFNumbers& v_s) const;
 
   /*! \brief given an arbitrary view/segment, find the basic view/segment
   
@@ -86,14 +86,14 @@ public:
   'v_s' is changed (i.e. it was NOT a basic view/segment).
   */  
   virtual bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const = 0;
+    find_basic_view_segment_numbers(ViewSegmentTOFNumbers& v_s) const = 0;
 
   /*! \brief test if a view/segment is 'basic' 
 
   The default implementation uses find_basic_view_segment_numbers
   */
   virtual bool
-    is_basic(const ViewSegmentNumbers& v_s) const;
+    is_basic(const ViewSegmentTOFNumbers& v_s) const;
 
  protected:
   typedef DataSymmetriesForViewSegmentNumbers root_type;

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -44,7 +44,7 @@ template <typename elemT> class SegmentBySinogram;
 template <typename elemT> class SegmentByView;
 template <typename elemT> class Viewgram;
 template <typename elemT> class Sinogram;
-class ViewSegmentNumbers;
+class ViewSegmentTOFNumbers;
 class Succeeded;
 //class ExamInfo;
 
@@ -174,7 +174,7 @@ public:
 
   //! Get related viewgrams
   virtual RelatedViewgrams<float> 
-    get_related_viewgrams(const ViewSegmentNumbers&,
+    get_related_viewgrams(const ViewSegmentTOFNumbers&,
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>&,
     const bool make_num_tangential_poss_odd = false) const;
   //! Set related viewgrams
@@ -185,7 +185,7 @@ public:
 
   //! Get empty related viewgrams, where the symmetries_ptr specifies the symmetries to use
   RelatedViewgrams<float> 
-    get_empty_related_viewgrams(const ViewSegmentNumbers& view_segmnet_num,
+    get_empty_related_viewgrams(const ViewSegmentTOFNumbers& view_segmnet_num,
     //const int view_num, const int segment_num, 
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_ptr,
     const bool make_num_tangential_poss_odd = false) const;

--- a/src/include/stir/ProjData.h
+++ b/src/include/stir/ProjData.h
@@ -176,8 +176,7 @@ public:
   virtual RelatedViewgrams<float> 
     get_related_viewgrams(const ViewSegmentNumbers&,
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>&,
-    const bool make_num_tangential_poss_odd = false,
-	const int timing_pos = 0) const;
+    const bool make_num_tangential_poss_odd = false) const;
   //! Set related viewgrams
   virtual Succeeded set_related_viewgrams(const RelatedViewgrams<float>& viewgrams);
 //  //! Get related bin values
@@ -189,8 +188,7 @@ public:
     get_empty_related_viewgrams(const ViewSegmentNumbers& view_segmnet_num,
     //const int view_num, const int segment_num, 
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_ptr,
-    const bool make_num_tangential_poss_odd = false,
-	const int timing_pos = 0) const;
+    const bool make_num_tangential_poss_odd = false) const;
 
 
   //! set all bins to the same value

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -42,7 +42,7 @@ template <typename elemT> class SegmentByView;
 template <typename elemT> class SegmentBySinogram;
 template <typename elemT> class RelatedViewgrams;
 class DataSymmetriesForViewSegmentNumbers;
-class ViewSegmentNumbers;
+class ViewSegmentTOFNumbers;
 class Bin;
 template <typename T> class LOR;
 template <typename T> class LORInAxialAndNoArcCorrSinogramCoordinates;
@@ -405,7 +405,7 @@ public:
 
 
   //! Get empty related viewgrams, where the symmetries_ptr specifies the symmetries to use
-  RelatedViewgrams<float> get_empty_related_viewgrams(const ViewSegmentNumbers&,
+  RelatedViewgrams<float> get_empty_related_viewgrams(const ViewSegmentTOFNumbers&,
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>&,
     const bool make_num_tangential_poss_odd = false) const;
   //@}

--- a/src/include/stir/ProjDataInfo.h
+++ b/src/include/stir/ProjDataInfo.h
@@ -407,8 +407,7 @@ public:
   //! Get empty related viewgrams, where the symmetries_ptr specifies the symmetries to use
   RelatedViewgrams<float> get_empty_related_viewgrams(const ViewSegmentNumbers&,
     const shared_ptr<DataSymmetriesForViewSegmentNumbers>&,
-    const bool make_num_tangential_poss_odd = false,
-	const int timing_pos_num = 0) const;
+    const bool make_num_tangential_poss_odd = false) const;
   //@}
 
 

--- a/src/include/stir/RelatedViewgrams.h
+++ b/src/include/stir/RelatedViewgrams.h
@@ -89,7 +89,7 @@ public:
   inline int get_basic_timing_pos_num() const;
   //! get 'basic' view_segment_num
   /*! see DataSymmetriesForViewSegmentNumbers for definition of 'basic' */
-  inline ViewSegmentNumbers get_basic_view_segment_num() const;
+  inline ViewSegmentTOFNumbers get_basic_view_segment_num() const;
 
   //! returns the number of viewgrams in this object
   inline int get_num_viewgrams() const;

--- a/src/include/stir/RelatedViewgrams.inl
+++ b/src/include/stir/RelatedViewgrams.inl
@@ -82,7 +82,7 @@ template <typename elemT>
 ViewSegmentNumbers RelatedViewgrams<elemT>::
 get_basic_view_segment_num() const
 {
-  return ViewSegmentNumbers(get_basic_view_num(), get_basic_segment_num());
+  return ViewSegmentNumbers(get_basic_view_num(), get_basic_segment_num(), get_basic_timing_pos_num());
 }
 
 template <typename elemT>

--- a/src/include/stir/RelatedViewgrams.inl
+++ b/src/include/stir/RelatedViewgrams.inl
@@ -20,7 +20,7 @@
 
     See STIR/LICENSE.txt for details
 */
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 
 START_NAMESPACE_STIR
 
@@ -79,10 +79,10 @@ int RelatedViewgrams<elemT>::get_basic_timing_pos_num() const
 }
 
 template <typename elemT>
-ViewSegmentNumbers RelatedViewgrams<elemT>::
+ViewSegmentTOFNumbers RelatedViewgrams<elemT>::
 get_basic_view_segment_num() const
 {
-  return ViewSegmentNumbers(get_basic_view_num(), get_basic_segment_num(), get_basic_timing_pos_num());
+  return ViewSegmentTOFNumbers(get_basic_view_num(), get_basic_segment_num(), get_basic_timing_pos_num());
 }
 
 template <typename elemT>

--- a/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.h
+++ b/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.h
@@ -28,7 +28,7 @@ START_NAMESPACE_STIR
 
 /*!
   \brief A class for encoding/finding NO symmetries. Works only on
-  ViewSegmentNumbers (instead of Bin).
+  ViewSegmentTOFNumbers (instead of Bin).
 
   This class is mainly useful if you need a DataSymmetriesForViewSegmentNumbers
   object (e.g. for RelatedViewgrams), but do not need/have projectors.
@@ -49,10 +49,10 @@ public:
 #endif
 
   virtual inline void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers& v_s) const;
+    get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>&, const ViewSegmentTOFNumbers& v_s) const;
 
   virtual inline int
-    num_related_view_segment_numbers(const ViewSegmentNumbers& v_s) const;
+    num_related_view_segment_numbers(const ViewSegmentTOFNumbers& v_s) const;
 
   /*! \brief given an arbitrary view/segment, find the basic view/segment
   
@@ -60,7 +60,7 @@ public:
   'v_s' is changed (i.e. it was NOT a basic view/segment).
   */  
   virtual inline bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const;
+    find_basic_view_segment_numbers(ViewSegmentTOFNumbers& v_s) const;
 
 private:
   virtual bool blindly_equals(const root_type * const) const;

--- a/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.inl
+++ b/src/include/stir/TrivialDataSymmetriesForViewSegmentNumbers.inl
@@ -31,7 +31,7 @@ clone() const
 
 void
 TrivialDataSymmetriesForViewSegmentNumbers::
-get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& all, const ViewSegmentNumbers& v_s) const
+get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>& all, const ViewSegmentTOFNumbers& v_s) const
 {
   all.resize(1);
   all[0] = v_s;
@@ -40,14 +40,14 @@ get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& all, const Vie
 
 int
 TrivialDataSymmetriesForViewSegmentNumbers::
-num_related_view_segment_numbers(const ViewSegmentNumbers& v_s) const
+num_related_view_segment_numbers(const ViewSegmentTOFNumbers& v_s) const
 {
   return 1;
 }
 
 bool
 TrivialDataSymmetriesForViewSegmentNumbers::
-find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const
+find_basic_view_segment_numbers(ViewSegmentTOFNumbers& v_s) const
 {
   return false;
 }

--- a/src/include/stir/ViewSegmentNumbers.inl
+++ b/src/include/stir/ViewSegmentNumbers.inl
@@ -23,14 +23,15 @@
 
 START_NAMESPACE_STIR
 
-ViewSegmentTOFNumbers::ViewSegmentTOFNumbers()
-:segment(0),view(0)
-  {}
+ViewSegmentTOFNumbers::
+ViewSegmentTOFNumbers()
+:segment(0), view(0), tof(0)
+{}
 
-ViewSegmentTOFNumbers::ViewSegmentTOFNumbers( const int view_num,const int segment_num,
-                                        const int tof_num)
-    : segment(segment_num),view(view_num),tof(tof_num)
-  {}
+ViewSegmentTOFNumbers::
+ViewSegmentTOFNumbers(const int view_num, const int segment_num, const int tof_num)
+:segment(segment_num), view(view_num), tof(tof_num)
+{}
 
 int
 ViewSegmentTOFNumbers::segment_num() const

--- a/src/include/stir/ViewSegmentNumbers.inl
+++ b/src/include/stir/ViewSegmentNumbers.inl
@@ -2,7 +2,7 @@
   \file
   \ingroup projdata
 
-  \brief inline implementations for class stir::ViewSegmentNumbers
+  \brief inline implementations for class stir::ViewSegmentTOFNumbers
 
   \author Kris Thielemans
   \author Sanida Mustafovic
@@ -23,58 +23,58 @@
 
 START_NAMESPACE_STIR
 
-ViewSegmentNumbers::ViewSegmentNumbers()
+ViewSegmentTOFNumbers::ViewSegmentTOFNumbers()
 :segment(0),view(0)
   {}
 
-ViewSegmentNumbers::ViewSegmentNumbers( const int view_num,const int segment_num,
+ViewSegmentTOFNumbers::ViewSegmentTOFNumbers( const int view_num,const int segment_num,
                                         const int tof_num)
     : segment(segment_num),view(view_num),tof(tof_num)
   {}
 
 int
-ViewSegmentNumbers::segment_num() const
+ViewSegmentTOFNumbers::segment_num() const
 {
   return segment;}
 int 
-ViewSegmentNumbers::view_num() const
+ViewSegmentTOFNumbers::view_num() const
 {
   return view;}
 
 int
-ViewSegmentNumbers::tof_pos_num() const
+ViewSegmentTOFNumbers::tof_pos_num() const
 {
   return tof;}
 
 int&
-ViewSegmentNumbers::segment_num() 
+ViewSegmentTOFNumbers::segment_num()
 {  return segment;}
 int& 
-ViewSegmentNumbers::view_num() 
+ViewSegmentTOFNumbers::view_num()
 { return view;}
 
 int&
-ViewSegmentNumbers::tof_pos_num()
+ViewSegmentTOFNumbers::tof_pos_num()
 { return tof;}
 
 bool 
-ViewSegmentNumbers::
-operator<(const ViewSegmentNumbers& other) const
+ViewSegmentTOFNumbers::
+operator<(const ViewSegmentTOFNumbers& other) const
 {
   return (view< other.view) ||
     ((view == other.view) && (segment > other.segment));
 }
 
 bool 
-ViewSegmentNumbers::
-operator==(const ViewSegmentNumbers& other) const
+ViewSegmentTOFNumbers::
+operator==(const ViewSegmentTOFNumbers& other) const
 {
   return (view == other.view) && (segment == other.segment) && (tof == other.tof);
 }
 
 bool 
-ViewSegmentNumbers::
-operator!=(const ViewSegmentNumbers& other) const
+ViewSegmentTOFNumbers::
+operator!=(const ViewSegmentTOFNumbers& other) const
 {
   return !(*this == other);
 }

--- a/src/include/stir/ViewSegmentTOFNumbers.h
+++ b/src/include/stir/ViewSegmentTOFNumbers.h
@@ -1,0 +1,89 @@
+//
+//
+/*!
+  \file
+  \ingroup projdata
+
+  \brief Definition of class stir::ViewSegmentTOFNumbers
+
+  \author Kris Thielemans
+  \author Sanida Mustafovic
+  \author PARAPET project
+  
+*/
+/*
+    Copyright (C) 2000 PARAPET partners
+    Copyright (C) 2000- 2009, Hammersmith Imanet Ltd
+    This file is part of STIR.
+
+    This file is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This file is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    See STIR/LICENSE.txt for details
+*/
+
+
+
+#ifndef __stir_ViewSegmentNumbers_h__
+#define __stir_ViewSegmentNumbers_h__
+
+#include "stir/common.h"
+
+START_NAMESPACE_STIR
+
+/*!
+  \brief A very simple class to store view and segment numbers 
+  \ingroup projdata 
+*/
+class ViewSegmentTOFNumbers
+{
+public:
+
+  //! an empty constructor (sets everything to 0)
+  inline  ViewSegmentTOFNumbers();
+  //! constructor taking view and segment number as arguments
+  inline ViewSegmentTOFNumbers( const int view_num, const int segment_num,
+                             const int tof_num = 0);
+
+  //! get segment number for const objects
+  inline int segment_num() const;
+  //! get view number for const objects
+  inline int view_num() const;
+  //! get tof number for const objects
+  inline int tof_pos_num() const;
+
+  //! get reference to segment number
+  inline int&  segment_num();
+  //! get reference to view number
+  inline int&  view_num();
+  //! get reference to timing position index
+  inline int& tof_pos_num();
+
+ 
+  //! comparison operator, only useful for sorting
+  /*! order : (0,1) < (0,-1) < (1,1) ...*/
+  inline bool operator<(const ViewSegmentTOFNumbers& other) const;
+
+  //! test for equality
+  inline bool operator==(const ViewSegmentTOFNumbers& other) const;
+  inline bool operator!=(const ViewSegmentTOFNumbers& other) const;
+
+private:
+  int segment;
+  int view;
+  int tof;
+
+};
+
+END_NAMESPACE_STIR
+
+#include "stir/ViewSegmentNumbers.inl"
+
+#endif

--- a/src/include/stir/ViewSegmentTOFNumbers.h
+++ b/src/include/stir/ViewSegmentTOFNumbers.h
@@ -48,9 +48,8 @@ public:
 
   //! an empty constructor (sets everything to 0)
   inline  ViewSegmentTOFNumbers();
-  //! constructor taking view and segment number as arguments
-  inline ViewSegmentTOFNumbers( const int view_num, const int segment_num,
-                             const int tof_num = 0);
+  //! constructor taking view, segment and tof number as arguments
+  inline ViewSegmentTOFNumbers( const int view_num, const int segment_num, const int tof_num=0);
 
   //! get segment number for const objects
   inline int segment_num() const;

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins.h
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins.h
@@ -46,7 +46,7 @@ class BinIndexRange;
 
 /*! 
   \brief AxTangPosNumbers as a class that provides the 2 remaining
-  coordinates for a Bin, aside from ViewSegmentNumbers.
+  coordinates for a Bin, aside from ViewSegmentTOFNumbers.
 
   TODO? something more sofisticated than a typedef
 */
@@ -123,7 +123,7 @@ public:
  //! fills in a vector with the axial and tangential position numbers related to this bin
   /*!
      It is guaranteed (or at least, it should be by the implementation of the derived class)
-     that these AxTangPosNumbers are related for all related ViewSegmentNumbers
+     that these AxTangPosNumbers are related for all related ViewSegmentTOFNumbers
      for this bin.
 
      So, you can find all related bins by calling get_related_ViewSegmentNumbers()
@@ -166,7 +166,7 @@ public:
 
   //! default implementation in terms of find_symmetry_operation_from_basic_bin
   virtual unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers&) const;
+    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentTOFNumbers&) const;
 
 
 protected:

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.h
@@ -26,7 +26,7 @@
 
 #include "stir/recon_buildblock/DataSymmetriesForBins.h"
 //#include "stir/SymmetryOperations_PET_CartesianGrid.h"
-//#include "stir/ViewSegmentNumbers.h"
+//#include "stir/ViewSegmentTOFNumbers.h"
 //#include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/Bin.h"
 #include "stir/shared_ptr.h"
@@ -122,13 +122,13 @@ public:
     find_basic_bin(Bin& b) const;
   
   inline int
-    num_related_view_segment_numbers(const ViewSegmentNumbers& vs) const;
+    num_related_view_segment_numbers(const ViewSegmentTOFNumbers& vs) const;
   
   inline void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const ViewSegmentNumbers& vs) const;
+    get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>& rel_vs, const ViewSegmentTOFNumbers& vs) const;
   
   inline bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const;
+    find_basic_view_segment_numbers(ViewSegmentTOFNumbers& v_s) const;
 
   //! find out how many image planes there are for every scanner ring
   inline float get_num_planes_per_scanner_ring() const;

--- a/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.inl
+++ b/src/include/stir/recon_buildblock/DataSymmetriesForBins_PET_CartesianGrid.inl
@@ -295,7 +295,7 @@ find_sym_op_general_bin(
 
 bool  
 DataSymmetriesForBins_PET_CartesianGrid::
-find_basic_view_segment_numbers(ViewSegmentNumbers& v_s) const 
+find_basic_view_segment_numbers(ViewSegmentTOFNumbers& v_s) const
 {
    bool change=false;
  // TODO get rid of next 2 restrictions
@@ -333,7 +333,7 @@ bool
 DataSymmetriesForBins_PET_CartesianGrid::
 find_basic_bin(int &segment_num, int &view_num, int &axial_pos_num, int &tangential_pos_num) const 
 {
-  ViewSegmentNumbers v_s(view_num, segment_num);
+  ViewSegmentTOFNumbers v_s(view_num, segment_num);
 
   bool change=find_basic_view_segment_numbers(v_s);
 
@@ -373,7 +373,7 @@ DataSymmetriesForBins_PET_CartesianGrid::
 
 int
 DataSymmetriesForBins_PET_CartesianGrid::
-num_related_view_segment_numbers(const ViewSegmentNumbers& vs) const
+num_related_view_segment_numbers(const ViewSegmentTOFNumbers& vs) const
 {      
   int num = do_symmetry_180degrees_min_phi  && (vs.view_num() % (num_views/2)) != 0 ? 2 : 1;
   if (do_symmetry_90degrees_min_phi && (vs.view_num() % (num_views/2)) != num_views/4)
@@ -424,11 +424,11 @@ get_related_bins_factorised(std::vector<AxTangPosNumbers>& ax_tang_poss, const B
     
 void
 DataSymmetriesForBins_PET_CartesianGrid::
-get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const ViewSegmentNumbers& vs) const
+get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>& rel_vs, const ViewSegmentTOFNumbers& vs) const
 {
 #ifndef NDEBUG
   {
-    ViewSegmentNumbers vstest=vs;
+    ViewSegmentTOFNumbers vstest=vs;
     assert(find_basic_view_segment_numbers(vstest)==false);
   }
 #endif
@@ -442,10 +442,10 @@ get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const 
   rel_vs.reserve(num_related_view_segment_numbers(vs));
   rel_vs.resize(0);
 
-  rel_vs.push_back(ViewSegmentNumbers(view_num,segment_num));
+  rel_vs.push_back(ViewSegmentTOFNumbers(view_num,segment_num));
 
   if (symz)
-    rel_vs.push_back(ViewSegmentNumbers(view_num,-segment_num));
+    rel_vs.push_back(ViewSegmentTOFNumbers(view_num,-segment_num));
 
   if (do_symmetry_180degrees_min_phi && do_symmetry_90degrees_min_phi && (view_num % (num_views/2)) != num_views/4)
   {
@@ -453,16 +453,16 @@ get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const 
       view_num < num_views/2 ?
       view_num + num_views/2 :
       view_num - num_views/2;
-    rel_vs.push_back(ViewSegmentNumbers( related_view_num,segment_num));
+    rel_vs.push_back(ViewSegmentTOFNumbers( related_view_num,segment_num));
     if (symz)
-      rel_vs.push_back(ViewSegmentNumbers( related_view_num,-segment_num));
+      rel_vs.push_back(ViewSegmentTOFNumbers( related_view_num,-segment_num));
   }
 
   if (do_symmetry_180degrees_min_phi && (view_num % (num_views/2)) != 0)
   {
-    rel_vs.push_back(ViewSegmentNumbers( num_views - view_num,segment_num));
+    rel_vs.push_back(ViewSegmentTOFNumbers( num_views - view_num,segment_num));
     if (symz)
-      rel_vs.push_back(ViewSegmentNumbers( num_views - view_num,-segment_num));
+      rel_vs.push_back(ViewSegmentTOFNumbers( num_views - view_num,-segment_num));
   }
   if (do_symmetry_90degrees_min_phi && (view_num % (num_views/4)) != 0)
   {
@@ -470,9 +470,9 @@ get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>& rel_vs, const 
     // use modulo num_views (but add num_views first to ensure positivity)
     const int related_view_num = 
       (num_views/2 - view_num + num_views) % num_views;
-    rel_vs.push_back(ViewSegmentNumbers( related_view_num,segment_num));
+    rel_vs.push_back(ViewSegmentTOFNumbers( related_view_num,segment_num));
     if (symz)
-      rel_vs.push_back(ViewSegmentNumbers( related_view_num,-segment_num));
+      rel_vs.push_back(ViewSegmentTOFNumbers( related_view_num,-segment_num));
   }
 
 

--- a/src/include/stir/recon_buildblock/DistributedCachingInformation.h
+++ b/src/include/stir/recon_buildblock/DistributedCachingInformation.h
@@ -22,7 +22,7 @@
 
 */
 
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include <vector>
 #include <algorithm>
 
@@ -76,7 +76,7 @@ public:
   /*! \brief to be called at the beginning of the processing of a set of data
    * The caching data is kept, such that the cache will be re-used over multiple runs.
    */ 
-  void initialise_new_subiteration(const std::vector<ViewSegmentNumbers>& vs_nums_to_process);
+  void initialise_new_subiteration(const std::vector<ViewSegmentTOFNumbers>& vs_nums_to_process);
 	
   /*! \brief get the next work-package for a given processor
    * \warning this must only be called if there for sure is an unprocessed vs_num left, 
@@ -87,7 +87,7 @@ public:
    * This function updates internal cache values etc. The user can just repeatedly call
    * the function without worrying about the caching algorithm.
    */ 
-  bool get_unprocessed_vs_num(ViewSegmentNumbers& vs_num, int proc);
+  bool get_unprocessed_vs_num(ViewSegmentTOFNumbers& vs_num, int proc);
 	
 private:
 
@@ -95,17 +95,17 @@ private:
   int num_workers;
 
   //! stores which data that have to be processed in this subiteration
-  std::vector<ViewSegmentNumbers> vs_nums_to_process;	
+  std::vector<ViewSegmentTOFNumbers> vs_nums_to_process;
 
   //!stores the vs_nums in the cache of every processor
-  std::vector<std::vector<ViewSegmentNumbers> > proc_vs_nums;
+  std::vector<std::vector<ViewSegmentTOFNumbers> > proc_vs_nums;
 	
   //! marks the vs_num that still need to be processed
   /*! Has the same length as vs_nums_to_process */
   std::vector<bool> still_to_process;
 
   //! \brief find where \a vs_num is in vs_nums_to_process
-  int find_vs_num_position_in_list_to_process(const ViewSegmentNumbers& vs_num) const;
+  int find_vs_num_position_in_list_to_process(const ViewSegmentTOFNumbers& vs_num) const;
 
   //! \brief find the first vs_num which has not be processed at all
   int find_position_of_first_unprocessed() const;
@@ -118,7 +118,7 @@ private:
    * \param vs_num the vs_number to be saved to the processors list of cached numbers
    * Calls set_processed() to make sure we do not process it again.
    */
-  void add_vs_num_to_proc(int proc, const ViewSegmentNumbers& vs_num);
+  void add_vs_num_to_proc(int proc, const ViewSegmentTOFNumbers& vs_num);
 
   /*! \brief gets the vs_num which is (most likely) the oldest in cache of the specific processor
    * \param[out] vs_num will be set accordingly
@@ -126,7 +126,7 @@ private:
    * \return \c true if there was an unprocessed data-set in the cache of processor \a proc
    * This is called by get_unprocessed_vs_num
    */
-  bool get_oldest_unprocessed_vs_num(ViewSegmentNumbers& vs_num, int proc) const;
+  bool get_oldest_unprocessed_vs_num(ViewSegmentTOFNumbers& vs_num, int proc) const;
 
 	
   /*! \brief gets a vs_num of the processor, which has the most work left
@@ -138,12 +138,12 @@ private:
    * encourages load balancing without having a lot of extra communicatrions.
    * That way the probability of requesting already cached work is kept high.  
    */
-  ViewSegmentNumbers get_vs_num_of_proc_with_most_work_left(int proc) const;
+  ViewSegmentTOFNumbers get_vs_num_of_proc_with_most_work_left(int proc) const;
 		
-  /*! \brief set a ViewSegmentNumbers as already processed
+  /*! \brief set a ViewSegmentTOFNumbers as already processed
    * \param vs_num the vs_num to be set processed
    */
-  void set_processed(const ViewSegmentNumbers& vs_num);
+  void set_processed(const ViewSegmentTOFNumbers& vs_num);
 	
   /*! \brief reset all data to unprocessed
    */
@@ -153,7 +153,7 @@ private:
    * \param vs_num the view segment number to be checked
    * Also returns false if the \a vs_num is not in the list to process at all.
    */
-  bool is_still_to_be_processed(const ViewSegmentNumbers& vs_num) const;
+  bool is_still_to_be_processed(const ViewSegmentTOFNumbers& vs_num) const;
 
 };
 

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.h
@@ -137,7 +137,7 @@ protected:
   virtual bool actual_subsets_are_approximately_balanced(std::string& warning_message) const;
 
   void
-    add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const;
+    add_view_seg_to_sensitivity(const ViewSegmentTOFNumbers& view_seg_nums) const;
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
+++ b/src/include/stir/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.h
@@ -375,7 +375,7 @@ protected:
   shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr;
 #if 0
   void
-    add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view_seg_nums) const;
+    add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentTOFNumbers& view_seg_nums) const;
 #endif
 };
 

--- a/src/include/stir/recon_buildblock/SymmetryOperation.h
+++ b/src/include/stir/recon_buildblock/SymmetryOperation.h
@@ -28,7 +28,7 @@
 START_NAMESPACE_STIR
 
 template <int num_dimensions, class coordT> class BasicCoordinate;
-class ViewSegmentNumbers;
+class ViewSegmentTOFNumbers;
 class ProjMatrixElemsForOneBin;
 class ProjMatrixElemsForOneDensel;
 class Bin;
@@ -67,7 +67,7 @@ public:
   virtual void 
     transform_bin_coordinates(Bin&) const = 0;
   virtual void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const = 0;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const = 0;
   virtual void
     transform_image_coordinates(BasicCoordinate<3,int>&) const = 0;
 #if 0
@@ -100,7 +100,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin& b) const {}
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers& n) const {}
+    transform_view_segment_indices(ViewSegmentTOFNumbers& n) const {}
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const {}
   inline void 

--- a/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.h
+++ b/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.h
@@ -58,7 +58,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -87,7 +87,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -122,7 +122,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -155,7 +155,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -187,7 +187,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -219,7 +219,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -252,7 +252,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -283,7 +283,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -314,7 +314,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -346,7 +346,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -378,7 +378,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -410,7 +410,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -441,7 +441,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -472,7 +472,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -504,7 +504,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 
@@ -535,7 +535,7 @@ public:
   inline void 
     transform_bin_coordinates(Bin&) const;
   inline void 
-    transform_view_segment_indices(ViewSegmentNumbers&) const;
+    transform_view_segment_indices(ViewSegmentTOFNumbers&) const;
   inline void
     transform_image_coordinates(BasicCoordinate<3,int>& c) const;
 

--- a/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.inl
+++ b/src/include/stir/recon_buildblock/SymmetryOperations_PET_CartesianGrid.inl
@@ -29,7 +29,7 @@
    */
 
 #include "stir/BasicCoordinate.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/Bin.h"
 
 START_NAMESPACE_STIR
@@ -43,7 +43,7 @@ SymmetryOperation_PET_CartesianGrid_z_shift::
 
 void 
 SymmetryOperation_PET_CartesianGrid_z_shift::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
 }
  
@@ -65,7 +65,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmx_zq::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmx_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.view_num() = view180 - vs.view_num();
   assert(0<=vs.view_num());
@@ -94,7 +94,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmy_yx_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmy_yx_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.segment_num() *= -1;
   vs.view_num() += view180/2;
@@ -125,7 +125,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xy_yx_zq::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xy_yx_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.view_num() = view180/2 - vs.view_num();
   assert(0<=vs.view_num());
@@ -164,7 +164,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmy_yx::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmy_yx::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num() < view180/2)
   {
@@ -208,7 +208,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xy_yx::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xy_yx::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num() <= view180/2)
   {
@@ -255,7 +255,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmx::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmx::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num()!=0)
   {
@@ -297,7 +297,7 @@ SymmetryOperation_PET_CartesianGrid_swap_ymy::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_ymy::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num()!=0)
   {
@@ -331,7 +331,7 @@ SymmetryOperation_PET_CartesianGrid_swap_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.segment_num() *= -1;
 }
@@ -355,7 +355,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmx_ymy_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmx_ymy_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   
 }
@@ -393,7 +393,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xy_ymx_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xy_ymx_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num() < view180/2)
   {
@@ -440,7 +440,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xy_ymx::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xy_ymx::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num() < view180/2)
   {
@@ -487,7 +487,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmy_ymx::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmy_ymx::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   if (vs.view_num() <= view180/2)
   {
@@ -527,7 +527,7 @@ SymmetryOperation_PET_CartesianGrid_swap_ymy_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_ymy_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.segment_num() *= -1;
   vs.view_num()= view180 - vs.view_num();
@@ -555,7 +555,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmx_ymy::
 }
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmx_ymy::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.segment_num() *= -1;
 }
@@ -584,7 +584,7 @@ SymmetryOperation_PET_CartesianGrid_swap_xmy_ymx_zq::
 
 void 
 SymmetryOperation_PET_CartesianGrid_swap_xmy_ymx_zq::
-    transform_view_segment_indices(ViewSegmentNumbers& vs) const
+    transform_view_segment_indices(ViewSegmentTOFNumbers& vs) const
 {
   vs.segment_num() *= -1;
   vs.view_num() = view180/2 - vs.view_num();

--- a/src/include/stir/recon_buildblock/TrivialDataSymmetriesForBins.h
+++ b/src/include/stir/recon_buildblock/TrivialDataSymmetriesForBins.h
@@ -69,15 +69,15 @@ public:
     is_basic(const Bin& v_s) const;
 
   virtual unique_ptr<SymmetryOperation>
-    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers&) const;
+    find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentTOFNumbers&) const;
 
   virtual void
-    get_related_view_segment_numbers(std::vector<ViewSegmentNumbers>&, const ViewSegmentNumbers&) const;
+    get_related_view_segment_numbers(std::vector<ViewSegmentTOFNumbers>&, const ViewSegmentTOFNumbers&) const;
 
   virtual int
-    num_related_view_segment_numbers(const ViewSegmentNumbers&) const;
+    num_related_view_segment_numbers(const ViewSegmentTOFNumbers&) const;
   virtual bool
-    find_basic_view_segment_numbers(ViewSegmentNumbers&) const;
+    find_basic_view_segment_numbers(ViewSegmentTOFNumbers&) const;
 
 private:
   virtual bool blindly_equals(const root_type * const) const;

--- a/src/include/stir/recon_buildblock/distributed_functions.h
+++ b/src/include/stir/recon_buildblock/distributed_functions.h
@@ -150,12 +150,12 @@ namespace distributed
    */
   void send_double_values(double * values, int count, int tag, int destination);
         
-  /*! \brief send or broadcast ViewSegmentNumbers object
+  /*! \brief send or broadcast ViewSegmentTOFNumbers object
    * \param vs_num value to be sent
    * \param tag identifier to associate messages
    * \param destination the process id where to send the double values. If set to -1 a Broadcast will be done
    */
-  void send_view_segment_numbers(const stir::ViewSegmentNumbers& vs_num, int tag, int destination);
+  void send_view_segment_numbers(const stir::ViewSegmentTOFNumbers& vs_num, int tag, int destination);
         
   /*! \brief send or broadcast a projector-pair object
    * \param proj_pair_sptr value to be sent
@@ -298,14 +298,14 @@ namespace distributed
    */
   MPI_Status receive_double_values(double* values, int count, int tag);
         
-  /*! \brief receive a ViewSegmentNumbers object
+  /*! \brief receive a ViewSegmentTOFNumbers object
    * \param[out] vs_num value that will be set
    * \param tag identifier to associate messages
    * \returns MPI_Status object to query the source of the message
    *
    * The tag needs to be set to ARBITRARY_TAG (=8) if MPI_ANY_TAG shall be used
    */
-  MPI_Status receive_view_segment_numbers(stir::ViewSegmentNumbers& vs_num, int tag);
+  MPI_Status receive_view_segment_numbers(stir::ViewSegmentTOFNumbers& vs_num, int tag);
         
   /*! \brief receives the parameters of a DiscretisedDensity object
    * \param image_ptr address pointer of the new DiscretisedDensity 

--- a/src/include/stir/recon_buildblock/find_basic_vs_nums_in_subsets.h
+++ b/src/include/stir/recon_buildblock/find_basic_vs_nums_in_subsets.h
@@ -19,7 +19,7 @@
 */
 
 
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include <vector>
 
 START_NAMESPACE_STIR
@@ -38,7 +38,7 @@ namespace detail
     to construct a list of view/segments that are in a subset, and which are
     "basic" w.r.t the symmetries.
   */
-  std::vector<ViewSegmentNumbers> 
+  std::vector<ViewSegmentTOFNumbers>
   find_basic_vs_nums_in_subset(const ProjDataInfo& proj_data_info,
                                const DataSymmetriesForViewSegmentNumbers& symmetries, 
                                const int min_segment_num, const int max_segment_num,

--- a/src/include/stir/scatter/ScatterSimulation.h
+++ b/src/include/stir/scatter/ScatterSimulation.h
@@ -230,7 +230,7 @@ protected:
     //! computes scatter for one viewgram
     /*! \return total scatter estimated for this viewgram */
     virtual double
-    process_data_for_view_segment_num(const ViewSegmentNumbers& vs_num);
+    process_data_for_view_segment_num(const ViewSegmentTOFNumbers& vs_num);
 
     float
     compute_emis_to_det_points_solid_angle_factor(const CartesianCoordinate3D<float>& emis_point,

--- a/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
+++ b/src/iterative/KOSMAPOSL/KOSMAPOSLReconstruction.cxx
@@ -41,7 +41,7 @@
 #include "stir/utilities.h"
 // for get_symmetries_ptr()
 #include "stir/DataSymmetriesForViewSegmentNumbers.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/stream.h"
 #include "stir/info.h"
 #include "stir/VoxelsOnCartesianGrid.h"

--- a/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
+++ b/src/iterative/OSMAPOSL/OSMAPOSLReconstruction.cxx
@@ -41,7 +41,7 @@
 #include "stir/utilities.h"
 // for get_symmetries_ptr()
 #include "stir/DataSymmetriesForViewSegmentNumbers.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/info.h"
 
 #include "stir/modelling/ParametricDiscretisedDensity.h"

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -165,7 +165,7 @@ back_project(DiscretisedDensity<3,float>& density,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("BackProjectorByBin::back_project called with incorrect related_viewgrams. Problem with symmetries!\n");
@@ -194,7 +194,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
   shared_ptr<DataSymmetriesForViewSegmentNumbers>
     symmetries_sptr(this->get_symmetries_used()->clone());
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_sptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
@@ -209,7 +209,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
       {
-        const ViewSegmentNumbers vs=vs_nums_to_process[i];
+        const ViewSegmentTOFNumbers vs=vs_nums_to_process[i];
 
 #ifdef STIR_OPENMP
         RelatedViewgrams<float> viewgrams;
@@ -278,7 +278,7 @@ back_project(const RelatedViewgrams<float>& viewgrams,
 
   // first check symmetries
   {
-    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+    const ViewSegmentTOFNumbers basic_vs = viewgrams.get_basic_view_segment_num();
 
     if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
       viewgrams.get_num_viewgrams())
@@ -288,7 +288,7 @@ back_project(const RelatedViewgrams<float>& viewgrams,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("BackProjectorByBin::back_project called with incorrect related_viewgrams. Problem with symmetries!\n");

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -288,7 +288,7 @@ back_project(const RelatedViewgrams<float>& viewgrams,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num(), iter->get_timing_pos_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("BackProjectorByBin::back_project called with incorrect related_viewgrams. Problem with symmetries!\n");

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -217,7 +217,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
         viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
 #else
         const RelatedViewgrams<float> viewgrams = 
-          proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
+          proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
 #endif
 
         info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num(), 2);

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -214,10 +214,10 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
 #ifdef STIR_OPENMP
         RelatedViewgrams<float> viewgrams;
 #pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)
-        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
+        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr);
 #else
         const RelatedViewgrams<float> viewgrams = 
-          proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
+          proj_data.get_related_viewgrams(vs, symmetries_sptr);
 #endif
 
         info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num(), 2);

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -214,7 +214,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
 #ifdef STIR_OPENMP
         RelatedViewgrams<float> viewgrams;
 #pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)
-        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
+        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
 #else
         const RelatedViewgrams<float> viewgrams = 
           proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -211,22 +211,17 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
       {
         const ViewSegmentNumbers vs=vs_nums_to_process[i];
 
-        for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
-              k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
-      		  ++k)
-        {
 #ifdef STIR_OPENMP
         RelatedViewgrams<float> viewgrams;
 #pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)
-        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false, k);
+        viewgrams = proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
 #else
         const RelatedViewgrams<float> viewgrams = 
-          proj_data.get_related_viewgrams(vs, symmetries_sptr, false, k);
+          proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
 #endif
 
         info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num(), 2);
         back_project(viewgrams);
-      }
   }
   }
 #ifdef STIR_OPENMP

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -152,11 +152,6 @@ apply(ProjData& proj_data,
     {
       const ViewSegmentNumbers vs=vs_nums_to_process[i];
       
-      for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
-              k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
-    		  ++k)
-      {
-
 		  RelatedViewgrams<float> viewgrams;
 #ifdef STIR_OPENMP
 		  // reading/writing to streams is not safe in multi-threaded code
@@ -167,7 +162,7 @@ apply(ProjData& proj_data,
 #endif
 		  {
 			viewgrams =
-			  proj_data.get_related_viewgrams(vs, symmetries_sptr, false, k);
+			  proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
 		  }
 
       this->apply(viewgrams);
@@ -180,7 +175,6 @@ apply(ProjData& proj_data,
 		  }
       }
     }
-}
 
 void 
 BinNormalisation::
@@ -205,17 +199,13 @@ undo(ProjData& proj_data,
     {
       const ViewSegmentNumbers vs=vs_nums_to_process[i];
       
-      for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
-              k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
-    		  ++k)
-      {
 		  RelatedViewgrams<float> viewgrams;
 #ifdef STIR_OPENMP
 #pragma omp critical (BINNORMALISATION_UNDO__VIEWGRAMS)
 #endif
 		  {
 			viewgrams =
-			  proj_data.get_related_viewgrams(vs, symmetries_sptr,false,k);
+			  proj_data.get_related_viewgrams(vs, symmetries_sptr,false, vs.tof_pos_num());
 		  }
 
       this->undo(viewgrams);
@@ -228,7 +218,6 @@ undo(ProjData& proj_data,
 		  }
       }
     }
-}
 
  
 END_NAMESPACE_STIR

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -162,7 +162,7 @@ apply(ProjData& proj_data,
 #endif
 		  {
 			viewgrams =
-			  proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
+			  proj_data.get_related_viewgrams(vs, symmetries_sptr);
 		  }
 
       this->apply(viewgrams);
@@ -205,7 +205,7 @@ undo(ProjData& proj_data,
 #endif
 		  {
 			viewgrams =
-                    proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
+                    proj_data.get_related_viewgrams(vs, symmetries_sptr);
 		  }
 
       this->undo(viewgrams);

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -162,7 +162,7 @@ apply(ProjData& proj_data,
 #endif
 		  {
 			viewgrams =
-			  proj_data.get_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
+			  proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
 		  }
 
       this->apply(viewgrams);
@@ -205,7 +205,7 @@ undo(ProjData& proj_data,
 #endif
 		  {
 			viewgrams =
-			  proj_data.get_related_viewgrams(vs, symmetries_sptr,false, vs.tof_pos_num());
+                    proj_data.get_related_viewgrams(vs, symmetries_sptr, false);
 		  }
 
       this->undo(viewgrams);

--- a/src/recon_buildblock/BinNormalisation.cxx
+++ b/src/recon_buildblock/BinNormalisation.cxx
@@ -139,7 +139,7 @@ apply(ProjData& proj_data,
   if (is_null_ptr(symmetries_sptr))
     symmetries_sptr.reset(new TrivialDataSymmetriesForBins(proj_data.get_proj_data_info_sptr()->create_shared_clone()));
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process = 
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_sptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          0, 1/*subset_num, num_subsets*/);
@@ -150,7 +150,7 @@ apply(ProjData& proj_data,
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
     {
-      const ViewSegmentNumbers vs=vs_nums_to_process[i];
+      const ViewSegmentTOFNumbers vs=vs_nums_to_process[i];
       
 		  RelatedViewgrams<float> viewgrams;
 #ifdef STIR_OPENMP
@@ -186,7 +186,7 @@ undo(ProjData& proj_data,
   if (is_null_ptr(symmetries_sptr))
     symmetries_sptr.reset(new TrivialDataSymmetriesForBins(proj_data.get_proj_data_info_sptr()->create_shared_clone()));
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process = 
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_sptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          0, 1/*subset_num, num_subsets*/);
@@ -197,7 +197,7 @@ undo(ProjData& proj_data,
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
     {
-      const ViewSegmentNumbers vs=vs_nums_to_process[i];
+      const ViewSegmentTOFNumbers vs=vs_nums_to_process[i];
       
 		  RelatedViewgrams<float> viewgrams;
 #ifdef STIR_OPENMP

--- a/src/recon_buildblock/BinNormalisationFromECAT7.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT7.cxx
@@ -43,7 +43,7 @@
 #include "stir/IO/stir_ecat7.h"
 #include "stir/shared_ptr.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/IndexRange2D.h"
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"

--- a/src/recon_buildblock/BinNormalisationFromECAT8.cxx
+++ b/src/recon_buildblock/BinNormalisationFromECAT8.cxx
@@ -38,7 +38,7 @@
 #include "stir/DetectionPositionPair.h"
 #include "stir/shared_ptr.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/IndexRange2D.h"
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"

--- a/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
+++ b/src/recon_buildblock/BinNormalisationFromGEHDF5.cxx
@@ -39,7 +39,7 @@
 #include "stir/DetectionPositionPair.h"
 #include "stir/shared_ptr.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/IndexRange2D.h"
 #include "stir/IndexRange.h"
 #include "stir/Bin.h"

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -140,7 +140,7 @@ BinNormalisationFromProjData::apply(RelatedViewgrams<float>& viewgrams) const
     const ViewSegmentTOFNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
-    viewgrams *= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);
+    viewgrams *= norm_proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);
   }
 
 void 
@@ -151,7 +151,7 @@ undo(RelatedViewgrams<float>& viewgrams) const
     const ViewSegmentTOFNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
-    viewgrams /= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);
+    viewgrams /= norm_proj_data_ptr->get_related_viewgrams(vs_num, symmetries_sptr);
 
   }
 

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -140,8 +140,7 @@ BinNormalisationFromProjData::apply(RelatedViewgrams<float>& viewgrams) const
     const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
-    viewgrams *= 
-      norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false,timing_pos_num);
+    viewgrams *= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);
   }
 
 void 
@@ -152,8 +151,7 @@ undo(RelatedViewgrams<float>& viewgrams) const
     const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
-    viewgrams /= 
-      norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false, timing_pos_num);
+    viewgrams /= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);
 
   }
 

--- a/src/recon_buildblock/BinNormalisationFromProjData.cxx
+++ b/src/recon_buildblock/BinNormalisationFromProjData.cxx
@@ -21,7 +21,7 @@
 #include "stir/ProjData.h"
 #include "stir/shared_ptr.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/Succeeded.h"
 #include "stir/warning.h"
 #include "stir/error.h"
@@ -137,7 +137,7 @@ void
 BinNormalisationFromProjData::apply(RelatedViewgrams<float>& viewgrams) const 
   {
     this->check(*viewgrams.get_proj_data_info_sptr());
-    const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
+    const ViewSegmentTOFNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
     viewgrams *= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);
@@ -148,7 +148,7 @@ BinNormalisationFromProjData::
 undo(RelatedViewgrams<float>& viewgrams) const 
   {
     this->check(*viewgrams.get_proj_data_info_sptr());
-    const ViewSegmentNumbers vs_num=viewgrams.get_basic_view_segment_num();
+    const ViewSegmentTOFNumbers vs_num=viewgrams.get_basic_view_segment_num();
 	const int timing_pos_num = norm_proj_data_ptr->get_proj_data_info_sptr()->is_tof_data() ? viewgrams.get_basic_timing_pos_num() : 0;
     shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_sptr(viewgrams.get_symmetries_ptr()->clone());
     viewgrams /= norm_proj_data_ptr->get_related_viewgrams(vs_num,symmetries_sptr, false);

--- a/src/recon_buildblock/BinNormalisationSPECT.cxx
+++ b/src/recon_buildblock/BinNormalisationSPECT.cxx
@@ -32,7 +32,7 @@
 #include "stir/shared_ptr.h"
 #include "stir/IO/read_from_file.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/ProjData.h"
 #include "stir/IndexRange3D.h"
 #include "stir/IndexRange2D.h"

--- a/src/recon_buildblock/DataSymmetriesForBins.cxx
+++ b/src/recon_buildblock/DataSymmetriesForBins.cxx
@@ -23,7 +23,7 @@
 
 #include "stir/recon_buildblock/DataSymmetriesForBins.h"
 #include "stir/Bin.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/BasicCoordinate.h"
 #include "stir/recon_buildblock/SymmetryOperation.h"
 
@@ -92,14 +92,14 @@ get_related_bins(vector<Bin>& rel_b, const Bin& b,
   assert(!find_basic_bin(bin_copy));
 #endif
 
-  vector<ViewSegmentNumbers> vs;
+  vector<ViewSegmentTOFNumbers> vs;
   vector<AxTangPosNumbers> ax_tang_poss;
 
   get_related_bins_factorised(ax_tang_poss, b,
                               min_axial_pos_num, max_axial_pos_num,
                               min_tangential_pos_num, max_tangential_pos_num);
 
-  get_related_view_segment_numbers(vs, ViewSegmentNumbers(b.view_num(), b.segment_num()));
+  get_related_view_segment_numbers(vs, ViewSegmentTOFNumbers(b.view_num(), b.segment_num()));
 
   rel_b.reserve(ax_tang_poss.size() * vs.size());
   rel_b.resize(0);
@@ -109,7 +109,7 @@ get_related_bins(vector<Bin>& rel_b, const Bin& b,
     // VC bug work-around...
        std::
 #endif
-         vector<ViewSegmentNumbers>::const_iterator view_seg_ptr = vs.begin();
+         vector<ViewSegmentTOFNumbers>::const_iterator view_seg_ptr = vs.begin();
        view_seg_ptr != vs.end();
        ++view_seg_ptr)
   {
@@ -133,7 +133,7 @@ get_related_bins(vector<Bin>& rel_b, const Bin& b,
 
 unique_ptr<SymmetryOperation>
 DataSymmetriesForBins::
-find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers& vs) const
+find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentTOFNumbers& vs) const
 {
   Bin bin(vs.segment_num(), vs.view_num(),0,0);
 #ifndef NDEBUG

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -206,8 +206,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
                   % vs.view_num() % vs.segment_num() % vs.tof_pos_num());
     	  else
             info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
-          RelatedViewgrams<float> viewgrams =
-            proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false);
+          RelatedViewgrams<float> viewgrams = proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
           forward_project(viewgrams);
 #ifdef STIR_OPENMP
 #pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -264,7 +264,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num(), iter->get_timing_pos_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -201,16 +201,13 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
     {
       const ViewSegmentNumbers vs=vs_nums_to_process[i];
-      for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
-              k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
-    		  ++k)
-        {
           if (proj_data.get_proj_data_info_sptr()->is_tof_data())
-            info(boost::format("Processing view %1% of segment %2% of TOF bin %3%") % vs.view_num() % vs.segment_num() % k);
+            info(boost::format("Processing view %1% of segment %2% of TOF bin %3%")
+                  % vs.view_num() % vs.segment_num() % vs.tof_pos_num());
     	  else
             info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
           RelatedViewgrams<float> viewgrams =
-            proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false, k);
+            proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
           forward_project(viewgrams);
 #ifdef STIR_OPENMP
 #pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)
@@ -220,7 +217,6 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
               error("Error set_related_viewgrams in forward projecting");
           }
         }
-    }
 
 }
 

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -207,7 +207,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
     	  else
             info(boost::format("Processing view %1% of segment %2%") % vs.view_num() % vs.segment_num());
           RelatedViewgrams<float> viewgrams =
-            proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false, vs.tof_pos_num());
+            proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false);
           forward_project(viewgrams);
 #ifdef STIR_OPENMP
 #pragma omp critical (FORWARDPROJ_SETVIEWGRAMS)

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -138,7 +138,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
 
   // first check symmetries
   {
-    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+    const ViewSegmentTOFNumbers basic_vs = viewgrams.get_basic_view_segment_num();
 
     if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
       viewgrams.get_num_viewgrams())
@@ -148,7 +148,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");
@@ -190,7 +190,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
   shared_ptr<DataSymmetriesForViewSegmentNumbers>
     symmetries_sptr(this->get_symmetries_used()->clone());
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_data.get_proj_data_info_sptr(), *symmetries_sptr,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
@@ -200,7 +200,7 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
     {
-      const ViewSegmentNumbers vs=vs_nums_to_process[i];
+      const ViewSegmentTOFNumbers vs=vs_nums_to_process[i];
           if (proj_data.get_proj_data_info_sptr()->is_tof_data())
             info(boost::format("Processing view %1% of segment %2% of TOF bin %3%")
                   % vs.view_num() % vs.segment_num() % vs.tof_pos_num());
@@ -255,7 +255,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
 
   // first check symmetries
   {
-    const ViewSegmentNumbers basic_vs = viewgrams.get_basic_view_segment_num();
+    const ViewSegmentTOFNumbers basic_vs = viewgrams.get_basic_view_segment_num();
 
     if (get_symmetries_used()->num_related_view_segment_numbers(basic_vs) !=
       viewgrams.get_num_viewgrams())
@@ -265,7 +265,7 @@ forward_project(RelatedViewgrams<float>& viewgrams,
      iter != viewgrams.end();
      ++iter)
       {
-    ViewSegmentNumbers vs(iter->get_view_num(), iter->get_segment_num());
+    ViewSegmentTOFNumbers vs(iter->get_view_num(), iter->get_segment_num());
     get_symmetries_used()->find_basic_view_segment_numbers(vs);
     if (vs != basic_vs)
       error("ForwardProjectByBin: forward_project called with incorrect related_viewgrams. Problem with symmetries!\n");

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -375,11 +375,15 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
           view <= proj_data_info_sptr->get_max_view_num();
           view += this->num_subsets)
       {
-        const ViewSegmentNumbers view_segment_num(view, segment_num);
+        for (int timing_pos_num = proj_data_info_sptr->get_min_tof_pos_num();
+            proj_data_info_sptr->get_max_tof_pos_num(), timing_pos_num++;)
+        {
+          const ViewSegmentNumbers view_segment_num(view, segment_num, timing_pos_num);
 
-        if (! this->projector_pair_sptr->get_symmetries_used()->is_basic(view_segment_num))
-          continue;
-        this->add_view_seg_to_sensitivity(view_segment_num);
+          if (! this->projector_pair_sptr->get_symmetries_used()->is_basic(view_segment_num))
+            continue;
+          this->add_view_seg_to_sensitivity(view_segment_num);
+        }
       }
     }
     this->sens_backprojector_sptr->
@@ -391,10 +395,6 @@ void
 PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin<TargetT>::
 add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const
 {
-    int min_timing_pos_num = use_tofsens ? this->proj_data_info_sptr->get_min_tof_pos_num() : 0;
-    int max_timing_pos_num = use_tofsens ? this->proj_data_info_sptr->get_max_tof_pos_num() : 0;
-	for (int timing_pos_num = min_timing_pos_num; timing_pos_num <= max_timing_pos_num; ++timing_pos_num)
-	{
 		shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_used
         (this->projector_pair_sptr->get_symmetries_used()->clone());
 
@@ -419,7 +419,6 @@ add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const
             this->sens_backprojector_sptr->back_project(viewgrams,
 				min_ax_pos_num, max_ax_pos_num);
 		}
-	}
 
 }
 

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -399,8 +399,7 @@ add_view_seg_to_sensitivity(const ViewSegmentTOFNumbers& view_seg_nums) const
         (this->projector_pair_sptr->get_symmetries_used()->clone());
 
 		RelatedViewgrams<float> viewgrams =
-                proj_data_info_sptr->get_empty_related_viewgrams(
-                        view_seg_nums, symmetries_used, false);
+                proj_data_info_sptr->get_empty_related_viewgrams(view_seg_nums, symmetries_used);
 
 		viewgrams.fill(1.F);
 		// find efficiencies

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -33,7 +33,7 @@
 #include "stir/recon_buildblock/TrivialBinNormalisation.h"
 #include "stir/Viewgram.h"
 #include "stir/RelatedViewgrams.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/recon_array_functions.h"
 
 #include <iostream>
@@ -378,7 +378,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
         for (int timing_pos_num = proj_data_info_sptr->get_min_tof_pos_num();
             proj_data_info_sptr->get_max_tof_pos_num(), timing_pos_num++;)
         {
-          const ViewSegmentNumbers view_segment_num(view, segment_num, timing_pos_num);
+          const ViewSegmentTOFNumbers view_segment_num(view, segment_num, timing_pos_num);
 
           if (! this->projector_pair_sptr->get_symmetries_used()->is_basic(view_segment_num))
             continue;
@@ -393,7 +393,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
 template<typename TargetT>
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin<TargetT>::
-add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const
+add_view_seg_to_sensitivity(const ViewSegmentTOFNumbers& view_seg_nums) const
 {
 		shared_ptr<DataSymmetriesForViewSegmentNumbers> symmetries_used
         (this->projector_pair_sptr->get_symmetries_used()->clone());

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndListModeDataWithProjMatrixByBin.cxx
@@ -399,8 +399,8 @@ add_view_seg_to_sensitivity(const ViewSegmentNumbers& view_seg_nums) const
         (this->projector_pair_sptr->get_symmetries_used()->clone());
 
 		RelatedViewgrams<float> viewgrams =
-            proj_data_info_sptr->get_empty_related_viewgrams(
-				view_seg_nums, symmetries_used, false, timing_pos_num);
+                proj_data_info_sptr->get_empty_related_viewgrams(
+                        view_seg_nums, symmetries_used, false);
 
 		viewgrams.fill(1.F);
 		// find efficiencies

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -1074,7 +1074,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     // Compute: final_viewgram * F(input) / ybar_sq_viewgram
     // final_viewgram starts as measured data
     RelatedViewgrams<float> final_viewgram = this->get_proj_data().get_related_viewgrams(vs_nums_to_process[i],
-                                                                                         symmetries_sptr, 0);
+                                                                                         symmetries_sptr);
     {
       // Mult input_viewgram
       final_viewgram *= input_viewgrams_vec[i];

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -926,7 +926,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           RelatedViewgrams<float> tmp_viewgrams;
           // set tmp_viewgrams to geometric forward projection of input
           {
-            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr, 0);
+            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr);
             this->get_projector_pair().get_forward_projector_sptr()->
               forward_project(tmp_viewgrams);
           }
@@ -1016,7 +1016,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
   {
     const ViewSegmentTOFNumbers view_segment_num = vs_nums_to_process[i];
-    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr,0));
+    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr));
   }
 
 
@@ -1036,7 +1036,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     info(boost::format("calculating segment_num: %d, view_num: %d")
          % vs_nums_to_process[i].segment_num() % vs_nums_to_process[i].view_num(), 2);
 #endif
-    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
+    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
     this->get_projector_pair().get_forward_projector_sptr()->forward_project(input_viewgrams_vec[i]);
   }
 
@@ -1061,12 +1061,12 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     // Compute ybar_sq_viewgram = [ F(current_image_est) + additive ]^2
     RelatedViewgrams<float> ybar_sq_viewgram;
     {
-      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr, 0);
+      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
       this->get_projector_pair().get_forward_projector_sptr()->forward_project(ybar_sq_viewgram);
 
       //add additive sinogram to forward projection
       if (!(is_null_ptr(this->get_additive_proj_data_sptr())))
-        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
+        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
       // square ybar
       ybar_sq_viewgram *= ybar_sq_viewgram;
     }

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -812,7 +812,7 @@ add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentTOFNumbers& v
 	{
 		RelatedViewgrams<float> viewgrams =
 			this->proj_data_sptr->get_empty_related_viewgrams(view_seg_nums,
-				this->symmetries_sptr, false, timing_pos_num);
+				this->symmetries_sptr);
 		viewgrams.fill(1.F);
 		// find efficiencies
 		{
@@ -926,7 +926,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           RelatedViewgrams<float> tmp_viewgrams;
           // set tmp_viewgrams to geometric forward projection of input
           {
-            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr, 0);
+            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr);
             this->get_projector_pair().get_forward_projector_sptr()->
               forward_project(tmp_viewgrams);
           }
@@ -1016,7 +1016,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
   {
     const ViewSegmentTOFNumbers view_segment_num = vs_nums_to_process[i];
-    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr,0));
+    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr));
   }
 
 
@@ -1036,7 +1036,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     info(boost::format("calculating segment_num: %d, view_num: %d")
          % vs_nums_to_process[i].segment_num() % vs_nums_to_process[i].view_num(), 2);
 #endif
-    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
+    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
     this->get_projector_pair().get_forward_projector_sptr()->forward_project(input_viewgrams_vec[i]);
   }
 
@@ -1061,12 +1061,12 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     // Compute ybar_sq_viewgram = [ F(current_image_est) + additive ]^2
     RelatedViewgrams<float> ybar_sq_viewgram;
     {
-      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr, 0);
+      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
       this->get_projector_pair().get_forward_projector_sptr()->forward_project(ybar_sq_viewgram);
 
       //add additive sinogram to forward projection
       if (!(is_null_ptr(this->get_additive_proj_data_sptr())))
-        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
+        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
       // square ybar
       ybar_sq_viewgram *= ybar_sq_viewgram;
     }

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -926,7 +926,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           RelatedViewgrams<float> tmp_viewgrams;
           // set tmp_viewgrams to geometric forward projection of input
           {
-            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr);
+            tmp_viewgrams = this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr, 0);
             this->get_projector_pair().get_forward_projector_sptr()->
               forward_project(tmp_viewgrams);
           }
@@ -1016,7 +1016,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
   {
     const ViewSegmentNumbers view_segment_num = vs_nums_to_process[i];
-    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr));
+    input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr,0));
   }
 
 
@@ -1036,7 +1036,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     info(boost::format("calculating segment_num: %d, view_num: %d")
          % vs_nums_to_process[i].segment_num() % vs_nums_to_process[i].view_num(), 2);
 #endif
-    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
+    input_viewgrams_vec[i] = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
     this->get_projector_pair().get_forward_projector_sptr()->forward_project(input_viewgrams_vec[i]);
   }
 
@@ -1061,19 +1061,20 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
     // Compute ybar_sq_viewgram = [ F(current_image_est) + additive ]^2
     RelatedViewgrams<float> ybar_sq_viewgram;
     {
-      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
+      ybar_sq_viewgram = this->get_proj_data().get_empty_related_viewgrams(vs_nums_to_process[i], symmetries_sptr, 0);
       this->get_projector_pair().get_forward_projector_sptr()->forward_project(ybar_sq_viewgram);
 
       //add additive sinogram to forward projection
       if (!(is_null_ptr(this->get_additive_proj_data_sptr())))
-        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
+        ybar_sq_viewgram += this->get_additive_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr,0);
       // square ybar
       ybar_sq_viewgram *= ybar_sq_viewgram;
     }
 
     // Compute: final_viewgram * F(input) / ybar_sq_viewgram
     // final_viewgram starts as measured data
-    RelatedViewgrams<float> final_viewgram = this->get_proj_data().get_related_viewgrams(vs_nums_to_process[i], symmetries_sptr);
+    RelatedViewgrams<float> final_viewgram = this->get_proj_data().get_related_viewgrams(vs_nums_to_process[i],
+                                                                                         symmetries_sptr, 0);
     {
       // Mult input_viewgram
       final_viewgram *= input_viewgrams_vec[i];

--- a/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
+++ b/src/recon_buildblock/PoissonLogLikelihoodWithLinearModelForMeanAndProjData.cxx
@@ -504,7 +504,7 @@ actual_subsets_are_approximately_balanced(std::string& warning_message) const
 			 view_num <= this->proj_data_sptr->get_max_view_num();
 			 view_num += this->num_subsets)
 		  {
-			const ViewSegmentNumbers view_segment_num(view_num, segment_num);
+			const ViewSegmentTOFNumbers view_segment_num(view_num, segment_num);
 			if (!symmetries.is_basic(view_segment_num))
 			  continue;
 			num_vs_in_subset[subset_num] +=
@@ -789,7 +789,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
         view <= this->proj_data_sptr->get_max_view_num(); 
         view += this->num_subsets)
     {
-      const ViewSegmentNumbers view_segment_num(view, segment_num);
+      const ViewSegmentTOFNumbers view_segment_num(view, segment_num);
         
       if (!symmetries_sptr->is_basic(view_segment_num))
         continue;
@@ -804,7 +804,7 @@ add_subset_sensitivity(TargetT& sensitivity, const int subset_num) const
 template<typename TargetT>
 void
 PoissonLogLikelihoodWithLinearModelForMeanAndProjData<TargetT>::
-add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentNumbers& view_seg_nums) const
+add_view_seg_to_sensitivity(TargetT& sensitivity, const ViewSegmentTOFNumbers& view_seg_nums) const
 {
 	int min_timing_pos_num = use_tofsens ? -this->max_timing_pos_num_to_process : 0;
 	int max_timing_pos_num = use_tofsens ? this->max_timing_pos_num_to_process : 0;
@@ -887,7 +887,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
   this->get_projector_pair().get_forward_projector_sptr()->set_input(input);
   this->get_projector_pair().get_back_projector_sptr()->start_accumulating_in_new_target();
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(* this->get_proj_data().get_proj_data_info_sptr(),
 					 *symmetries_sptr,
 					 -this->get_max_segment_num_to_process(),
@@ -910,7 +910,7 @@ actual_add_multiplication_with_approximate_sub_Hessian_without_penalty(TargetT& 
           info(boost::format("calculating segment_num: %d, view_num: %d")
                % vs_nums_to_process[i].segment_num() % vs_nums_to_process[i].view_num(), 2);
 #endif
-          const ViewSegmentNumbers view_segment_num=vs_nums_to_process[i];
+          const ViewSegmentTOFNumbers view_segment_num=vs_nums_to_process[i];
 
           // first compute data-term: y*norm^2
           RelatedViewgrams<float> viewgrams =
@@ -999,7 +999,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   this->get_projector_pair().get_forward_projector_sptr()->set_input(input);
   this->get_projector_pair().get_back_projector_sptr()->start_accumulating_in_new_target();
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process =
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
           detail::find_basic_vs_nums_in_subset(* this->get_proj_data().get_proj_data_info_sptr(),
                                                *symmetries_sptr,
                                                -this->get_max_segment_num_to_process(),
@@ -1015,7 +1015,7 @@ actual_accumulate_sub_Hessian_times_input_without_penalty(TargetT& output,
   std::vector<RelatedViewgrams<float>> input_viewgrams_vec;
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
   {
-    const ViewSegmentNumbers view_segment_num = vs_nums_to_process[i];
+    const ViewSegmentTOFNumbers view_segment_num = vs_nums_to_process[i];
     input_viewgrams_vec.push_back(this->get_proj_data().get_empty_related_viewgrams(view_segment_num, symmetries_sptr,0));
   }
 

--- a/src/recon_buildblock/TrivialDataSymmetriesForBins.cxx
+++ b/src/recon_buildblock/TrivialDataSymmetriesForBins.cxx
@@ -19,7 +19,7 @@
 */
 #include "stir/recon_buildblock/TrivialDataSymmetriesForBins.h"
 #include "stir/recon_buildblock/SymmetryOperation.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 
 using std::vector;
 
@@ -118,14 +118,14 @@ find_symmetry_operation_from_basic_bin(Bin&) const
 
 unique_ptr<SymmetryOperation>
 TrivialDataSymmetriesForBins::
-find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentNumbers& vs) const
+find_symmetry_operation_from_basic_view_segment_numbers(ViewSegmentTOFNumbers& vs) const
 {
   return unique_ptr<SymmetryOperation>(new TrivialSymmetryOperation);
 }
 
 void
 TrivialDataSymmetriesForBins::
-get_related_view_segment_numbers(vector<ViewSegmentNumbers>& all, const ViewSegmentNumbers& v_s) const
+get_related_view_segment_numbers(vector<ViewSegmentTOFNumbers>& all, const ViewSegmentTOFNumbers& v_s) const
 {
   all.resize(1);
   all[0] = v_s;
@@ -134,14 +134,14 @@ get_related_view_segment_numbers(vector<ViewSegmentNumbers>& all, const ViewSegm
 
 int
 TrivialDataSymmetriesForBins::
-num_related_view_segment_numbers(const ViewSegmentNumbers&) const
+num_related_view_segment_numbers(const ViewSegmentTOFNumbers&) const
 {
   return 1;
 }
 
 bool
 TrivialDataSymmetriesForBins::
-find_basic_view_segment_numbers(ViewSegmentNumbers&) const
+find_basic_view_segment_numbers(ViewSegmentTOFNumbers&) const
 {
   return false;
 }

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -177,7 +177,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #if !defined(_MSC_VER) || _MSC_VER>1300
       additive_binwise_correction_viewgrams.reset(
         new RelatedViewgrams<float>
-        (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
+        (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr, false)));
 #else
       RelatedViewgrams<float> tmp(binwise_correction->
                                   get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num()));
@@ -192,7 +192,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #endif
 #if !defined(_MSC_VER) || _MSC_VER>1300
       y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
+	      (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr, false)));
 #else
       // workaround VC++ 6.0 bug
       RelatedViewgrams<float> tmp(proj_dat_ptr->
@@ -203,14 +203,14 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
   else
     {
       y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
+	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false)));
     }
 
   // multiplicative correction
   if (!is_null_ptr(normalisation_sptr) && !normalisation_sptr->is_trivial())
     {
       mult_viewgrams_sptr.reset(
-				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
+				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false)));
       mult_viewgrams_sptr->fill(1.F);
 #ifdef STIR_OPENMP
 #pragma omp critical(MULT)

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -173,15 +173,8 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #ifdef STIR_OPENMP
 #pragma omp critical(ADDSINO)
 #endif
-#if !defined(_MSC_VER) || _MSC_VER>1300
-      additive_binwise_correction_viewgrams.reset(
-        new RelatedViewgrams<float>
-        (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr, false)));
-#else
-      RelatedViewgrams<float> tmp(binwise_correction->
-                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num()));
-      additive_binwise_correction_viewgrams.reset(new RelatedViewgrams<float>(tmp));
-#endif
+    additive_binwise_correction_viewgrams.reset(
+          new RelatedViewgrams<float> (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr)));
     }
                         
   if (read_from_proj_dat)
@@ -189,15 +182,8 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #ifdef STIR_OPENMP
 #pragma omp critical(VIEW)
 #endif
-#if !defined(_MSC_VER) || _MSC_VER>1300
-      y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr, false)));
-#else
-      // workaround VC++ 6.0 bug
-      RelatedViewgrams<float> tmp(proj_dat_ptr->
-                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num()));
-      y.reset(new RelatedViewgrams<float>(tmp));
-#endif        
+    y.reset(
+          new RelatedViewgrams<float> (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr)));
     }
   else
     {

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -203,14 +203,14 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
   else
     {
       y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false)));
+	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr)));
     }
 
   // multiplicative correction
   if (!is_null_ptr(normalisation_sptr) && !normalisation_sptr->is_trivial())
     {
       mult_viewgrams_sptr.reset(
-				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false)));
+				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr)));
       mult_viewgrams_sptr->fill(1.F);
 #ifdef STIR_OPENMP
 #pragma omp critical(MULT)

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -165,8 +165,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
                    const double start_time_of_frame,
                    const double end_time_of_frame,
                    const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_ptr,
-                   const ViewSegmentTOFNumbers& view_segment_num,
-				   const int timing_pos_num
+                   const ViewSegmentTOFNumbers& view_segment_num
                    )
 {
   if (!is_null_ptr(binwise_correction))
@@ -448,7 +447,7 @@ void distributable_computation(
                       zero_seg0_end_planes,
                       binwise_correction,
                       normalisation_sptr, start_time_of_frame, end_time_of_frame,
-                      symmetries_ptr, view_segment_num, view_segment_num.tof_pos_num());
+                      symmetries_ptr, view_segment_num);
 #ifdef STIR_MPI     
 
           //send viewgrams, the slave will immediatelly start calculation

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -39,7 +39,7 @@
 #include "stir/ProjData.h"
 #include "stir/ExamInfo.h"
 #include "stir/DiscretisedDensity.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/CPUTimer.h"
 #include "stir/HighResWallClockTimer.h"
 #include "stir/recon_buildblock/ForwardProjectorByBin.h"
@@ -165,7 +165,7 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
                    const double start_time_of_frame,
                    const double end_time_of_frame,
                    const shared_ptr<DataSymmetriesForViewSegmentNumbers>& symmetries_ptr,
-                   const ViewSegmentNumbers& view_segment_num,
+                   const ViewSegmentTOFNumbers& view_segment_num,
 				   const int timing_pos_num
                    )
 {
@@ -397,7 +397,7 @@ void distributable_computation(
   if (zero_seg0_end_planes)
     info("End-planes of segment 0 will be zeroed");
 
-  const std::vector<ViewSegmentNumbers> vs_nums_to_process = 
+  const std::vector<ViewSegmentTOFNumbers> vs_nums_to_process =
     detail::find_basic_vs_nums_in_subset(*proj_dat_ptr->get_proj_data_info_sptr(), *symmetries_ptr,
                                          min_segment_num, max_segment_num,
                                          subset_num, num_subsets);
@@ -437,7 +437,7 @@ void distributable_computation(
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
       {
-        const ViewSegmentNumbers view_segment_num=vs_nums_to_process[i];
+        const ViewSegmentTOFNumbers view_segment_num=vs_nums_to_process[i];
 
         shared_ptr<RelatedViewgrams<float> > y;
         shared_ptr<RelatedViewgrams<float> > additive_binwise_correction_viewgrams;

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -177,10 +177,10 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #if !defined(_MSC_VER) || _MSC_VER>1300
       additive_binwise_correction_viewgrams.reset(
         new RelatedViewgrams<float>
-        (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num)));
+        (binwise_correction->get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
 #else
       RelatedViewgrams<float> tmp(binwise_correction->
-                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num));
+                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num()));
       additive_binwise_correction_viewgrams.reset(new RelatedViewgrams<float>(tmp));
 #endif
     }
@@ -192,25 +192,25 @@ void get_viewgrams(shared_ptr<RelatedViewgrams<float> >& y,
 #endif
 #if !defined(_MSC_VER) || _MSC_VER>1300
       y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num)));
+	      (proj_dat_ptr->get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
 #else
       // workaround VC++ 6.0 bug
       RelatedViewgrams<float> tmp(proj_dat_ptr->
-                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num));
+                                  get_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num()));
       y.reset(new RelatedViewgrams<float>(tmp));
 #endif        
     }
   else
     {
       y.reset(new RelatedViewgrams<float>
-	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num)));
+	      (proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
     }
 
   // multiplicative correction
   if (!is_null_ptr(normalisation_sptr) && !normalisation_sptr->is_trivial())
     {
       mult_viewgrams_sptr.reset(
-				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, timing_pos_num)));
+				new RelatedViewgrams<float>(proj_dat_ptr->get_empty_related_viewgrams(view_segment_num, symmetries_ptr, false, view_segment_num.tof_pos_num())));
       mult_viewgrams_sptr->fill(1.F);
 #ifdef STIR_OPENMP
 #pragma omp critical(MULT)
@@ -434,8 +434,6 @@ void distributable_computation(
 #pragma omp for schedule(dynamic)  
 #endif
 
-  for (int timing_pos_num = min_timing_pos_num; timing_pos_num <= max_timing_pos_num; ++timing_pos_num)
-  {
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
       {
@@ -450,7 +448,7 @@ void distributable_computation(
                       zero_seg0_end_planes,
                       binwise_correction,
                       normalisation_sptr, start_time_of_frame, end_time_of_frame,
-                      symmetries_ptr, view_segment_num, timing_pos_num);
+                      symmetries_ptr, view_segment_num, view_segment_num.tof_pos_num());
 #ifdef STIR_MPI     
 
           //send viewgrams, the slave will immediatelly start calculation
@@ -480,10 +478,10 @@ void distributable_computation(
           const int thread_num=omp_get_thread_num();
           info(boost::format("Thread %d/%d calculating segment_num: %d, view_num: %d, timing_pos_num: %d")
                % thread_num % omp_get_num_threads()
-               % view_segment_num.segment_num() % view_segment_num.view_num() % timing_pos_num, 2);
+               % view_segment_num.segment_num() % view_segment_num.view_num() % view_segment_num.tof_pos_num(), 2);
 #else
           info(boost::format("calculating segment_num: %d, view_num: %d, timing_pos_num: %d")
-               % view_segment_num.segment_num() % view_segment_num.view_num() % timing_pos_num,2);
+               % view_segment_num.segment_num() % view_segment_num.view_num() % view_segment_num.tof_pos_num(),2);
 #endif
 
 #ifdef STIR_OPENMP
@@ -504,7 +502,6 @@ void distributable_computation(
 #endif // OPENMP                                    
 #endif // MPI
         } // end of for-loop
-      } // end of for-loop over timing_pos_num
   } // end of parallel section of openmp
   
 #ifdef STIR_OPENMP

--- a/src/recon_buildblock/distributableMPICacheEnabled.cxx
+++ b/src/recon_buildblock/distributableMPICacheEnabled.cxx
@@ -37,7 +37,7 @@
 #include "stir/RelatedViewgrams.h"
 #include "stir/ProjData.h"
 #include "stir/DiscretisedDensity.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/CPUTimer.h"
 #include "stir/recon_buildblock/ForwardProjectorByBin.h"
 #include "stir/recon_buildblock/BackProjectorByBin.h"

--- a/src/recon_buildblock/distributed_functions.cxx
+++ b/src/recon_buildblock/distributed_functions.cxx
@@ -174,12 +174,13 @@ namespace distributed
 #endif
   }
 
-  void send_view_segment_numbers(const stir::ViewSegmentNumbers& vs_num, int tag, int destination)
+  void send_view_segment_numbers(const stir::ViewSegmentTOFNumbers& vs_num, int tag, int destination)
   {
-    int int_values[2];
+    int int_values[3];
     int_values[0]=vs_num.view_num();
     int_values[1]=vs_num.segment_num();    
-    distributed::send_int_values(int_values, 2, tag, destination);
+    int_values[2]=vs_num.tof_pos_num();
+    distributed::send_int_values(int_values, 3, tag, destination);
   }
 
   void send_image_parameters(const stir::DiscretisedDensity<3,float>* input_image_ptr, int tag, int destination)
@@ -532,12 +533,13 @@ namespace distributed
     return status;
   }
 
-  MPI_Status receive_view_segment_numbers(stir::ViewSegmentNumbers& vs_num, int tag)
+  MPI_Status receive_view_segment_numbers(stir::ViewSegmentTOFNumbers& vs_num, int tag)
   {
-    int int_values[2];
+    int int_values[3];
     const MPI_Status status = distributed::receive_int_values(int_values, 2, tag);
     vs_num.view_num() = int_values[0];
     vs_num.segment_num() = int_values[1];
+    vs_num.tof_pos_num() = int_values[2];
     return status;
   }
         

--- a/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
+++ b/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
@@ -37,7 +37,7 @@ namespace detail
     std::vector<ViewSegmentNumbers> vs_nums_to_process;
     for (int segment_num = min_segment_num; segment_num <= max_segment_num; segment_num++)
       {
-        for (int timing_pos_num = -proj_data_info.get_min_tof_pos_num();
+        for (int timing_pos_num = proj_data_info.get_min_tof_pos_num();
                       timing_pos_num<= proj_data_info.get_max_tof_pos_num();
                       ++timing_pos_num)
               {
@@ -45,7 +45,7 @@ namespace detail
              view <= proj_data_info.get_max_view_num(); 
              view += num_subsets)
           {
-            const ViewSegmentNumbers view_segment_num(view, segment_num);
+            const ViewSegmentNumbers view_segment_num(view, segment_num, timing_pos_num);
 
             if (!symmetries.is_basic(view_segment_num))
               continue;

--- a/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
+++ b/src/recon_buildblock/find_basic_vs_nums_in_subset.cxx
@@ -28,13 +28,13 @@ START_NAMESPACE_STIR
 namespace detail 
 {
 
-  std::vector<ViewSegmentNumbers> 
+  std::vector<ViewSegmentTOFNumbers>
   find_basic_vs_nums_in_subset(const ProjDataInfo& proj_data_info,
                                const DataSymmetriesForViewSegmentNumbers& symmetries, 
                                const int min_segment_num, const int max_segment_num,
                                const int subset_num, const int num_subsets)
   {
-    std::vector<ViewSegmentNumbers> vs_nums_to_process;
+    std::vector<ViewSegmentTOFNumbers> vs_nums_to_process;
     for (int segment_num = min_segment_num; segment_num <= max_segment_num; segment_num++)
       {
         for (int timing_pos_num = proj_data_info.get_min_tof_pos_num();
@@ -45,7 +45,7 @@ namespace detail
              view <= proj_data_info.get_max_view_num(); 
              view += num_subsets)
           {
-            const ViewSegmentNumbers view_segment_num(view, segment_num, timing_pos_num);
+            const ViewSegmentTOFNumbers view_segment_num(view, segment_num, timing_pos_num);
 
             if (!symmetries.is_basic(view_segment_num))
               continue;
@@ -54,9 +54,9 @@ namespace detail
       
 #ifndef NDEBUG
             // test if symmetries didn't take us out of the segment range
-            std::vector<ViewSegmentNumbers> rel_vs;
+            std::vector<ViewSegmentTOFNumbers> rel_vs;
             symmetries.get_related_view_segment_numbers(rel_vs, view_segment_num);
-            for (std::vector<ViewSegmentNumbers>::const_iterator iter = rel_vs.begin(); iter!= rel_vs.end(); ++iter)
+            for (std::vector<ViewSegmentTOFNumbers>::const_iterator iter = rel_vs.begin(); iter!= rel_vs.end(); ++iter)
               {
                 assert(iter->segment_num() >= min_segment_num);
                 assert(iter->segment_num() <= max_segment_num);

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -117,7 +117,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 			  if (fill_with_1)
 			  {
 				  RelatedViewgrams<float> viewgrams_empty =
-					  proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr, false, timing_num);
+					  proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr, false);
 				  //proj_data_org.get_empty_related_viewgrams(vs.view_num(),vs.segment_num(), symmetries_sptr);
 
 				  RelatedViewgrams<float>::iterator r_viewgrams_iter = viewgrams_empty.begin();
@@ -144,7 +144,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 				  RelatedViewgrams<float> viewgrams =
 					  proj_data_org.get_related_viewgrams(vs,
 						  //proj_data_org.get_related_viewgrams(vs.view_num(),vs.segment_num(),
-						  symmetries_sptr, false, timing_num);
+						  symmetries_sptr, false);
 				  RelatedViewgrams<float>::iterator r_viewgrams_iter = viewgrams.begin();
 
 				  while (r_viewgrams_iter != viewgrams.end())

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -116,8 +116,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 
 			  if (fill_with_1)
 			  {
-				  RelatedViewgrams<float> viewgrams_empty =
-					  proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr, false);
+				  RelatedViewgrams<float> viewgrams_empty = proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr);
 				  //proj_data_org.get_empty_related_viewgrams(vs.view_num(),vs.segment_num(), symmetries_sptr);
 
 				  RelatedViewgrams<float>::iterator r_viewgrams_iter = viewgrams_empty.begin();
@@ -144,7 +143,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 				  RelatedViewgrams<float> viewgrams =
 					  proj_data_org.get_related_viewgrams(vs,
 						  //proj_data_org.get_related_viewgrams(vs.view_num(),vs.segment_num(),
-						  symmetries_sptr, false);
+						  symmetries_sptr);
 				  RelatedViewgrams<float>::iterator r_viewgrams_iter = viewgrams.begin();
 
 				  while (r_viewgrams_iter != viewgrams.end())

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -116,8 +116,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 
 			  if (fill_with_1)
 			  {
-				  RelatedViewgrams<float> viewgrams_empty =
-					  proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr, false);
+				  RelatedViewgrams<float> viewgrams_empty = proj_data_org.get_empty_related_viewgrams(vs, symmetries_sptr);
 				  //proj_data_org.get_empty_related_viewgrams(vs.view_num(),vs.segment_num(), symmetries_sptr);
 
 				  RelatedViewgrams<float>::iterator r_viewgrams_iter = viewgrams_empty.begin();

--- a/src/recon_test/bcktest.cxx
+++ b/src/recon_test/bcktest.cxx
@@ -93,7 +93,7 @@ do_segments(DiscretisedDensity<3,float>& image,
     symmetries_sptr(back_projector_ptr->get_symmetries_used()->clone());
   
   
-  list<ViewSegmentNumbers> already_processed;
+  list<ViewSegmentTOFNumbers> already_processed;
   back_projector_ptr->start_accumulating_in_new_target();
   for (int timing_num = start_timing_num; timing_num <= end_timing_num; ++timing_num)
   {
@@ -101,7 +101,7 @@ do_segments(DiscretisedDensity<3,float>& image,
 	  for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
 		  for (int view = start_view; view <= end_view; view++)
 		  {
-			  ViewSegmentNumbers vs(view, segment_num);
+			  ViewSegmentTOFNumbers vs(view, segment_num);
 			  symmetries_sptr->find_basic_view_segment_numbers(vs);
 			  if (find(already_processed.begin(), already_processed.end(), vs)
 				  != already_processed.end())

--- a/src/recon_test/fwdtest.cxx
+++ b/src/recon_test/fwdtest.cxx
@@ -361,7 +361,7 @@ do_segments(const VoxelsOnCartesianGrid<float>& image,
 					<< endl;
 
 				RelatedViewgrams<float> viewgrams =
-					proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false,timing_pos_num);
+					proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false);
                 forw_projector.forward_project(viewgrams,
 					viewgrams.get_min_axial_pos_num(),
 					viewgrams.get_max_axial_pos_num(),

--- a/src/recon_test/fwdtest.cxx
+++ b/src/recon_test/fwdtest.cxx
@@ -360,8 +360,7 @@ do_segments(const VoxelsOnCartesianGrid<float>& image,
 					<< " of timing position index " << timing_pos_num
 					<< endl;
 
-				RelatedViewgrams<float> viewgrams =
-					proj_data.get_empty_related_viewgrams(vs, symmetries_sptr, false);
+				RelatedViewgrams<float> viewgrams = proj_data.get_empty_related_viewgrams(vs, symmetries_sptr);
                 forw_projector.forward_project(viewgrams,
 					viewgrams.get_min_axial_pos_num(),
 					viewgrams.get_max_axial_pos_num(),

--- a/src/recon_test/fwdtest.cxx
+++ b/src/recon_test/fwdtest.cxx
@@ -231,7 +231,7 @@ main(int argc, char *argv[])
       write_to_file("test_image", *image_sptr);
   }
     
-  std::list<ViewSegmentNumbers> already_processed;
+  std::list<ViewSegmentTOFNumbers> already_processed;
 
   if (ask("Do full forward projection ?", true))
   {    
@@ -340,14 +340,14 @@ do_segments(const VoxelsOnCartesianGrid<float>& image,
 	shared_ptr<DataSymmetriesForViewSegmentNumbers>
 		symmetries_sptr(forw_projector.get_symmetries_used()->clone());
 
-	std::list<ViewSegmentNumbers> already_processed;
+	std::list<ViewSegmentTOFNumbers> already_processed;
 	for (int timing_pos_num = start_timing_pos_num; timing_pos_num <= end_timing_pos_num; ++timing_pos_num)
 	{
 		already_processed.clear();
 		for (int segment_num = start_segment_num; segment_num <= end_segment_num; ++segment_num)
 			for (int view = start_view; view <= end_view; view++)
 			{
-				ViewSegmentNumbers vs(view, segment_num);
+				ViewSegmentTOFNumbers vs(view, segment_num);
 				symmetries_sptr->find_basic_view_segment_numbers(vs);
 				if (find(already_processed.begin(), already_processed.end(), vs)
 					!= already_processed.end())

--- a/src/scatter_buildblock/ScatterSimulation.cxx
+++ b/src/scatter_buildblock/ScatterSimulation.cxx
@@ -18,7 +18,7 @@
   \author Kris Thielemans
 */
 #include "stir/scatter/ScatterSimulation.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/Bin.h"
 #include "stir/CPUTimer.h"
 #include "stir/HighResWallClockTimer.h"
@@ -94,7 +94,7 @@ process_data()
     info("ScatterSimulator: Running Scatter Simulation ...");
     info("ScatterSimulator: Initialising ...");
 
-    ViewSegmentNumbers vs_num;
+    ViewSegmentTOFNumbers vs_num;
     /* ////////////////// SCATTER ESTIMATION TIME //////////////// */
     CPUTimer bin_timer;
     bin_timer.start();
@@ -165,7 +165,7 @@ process_data()
 
 double
 ScatterSimulation::
-process_data_for_view_segment_num(const ViewSegmentNumbers& vs_num)
+process_data_for_view_segment_num(const ViewSegmentTOFNumbers& vs_num)
 {
     // First construct a vector of all bins that we'll process.
     // The reason for making this list before the actual calculation is that we can then parallelise over all bins

--- a/src/test/test_time_of_flight.cxx
+++ b/src/test/test_time_of_flight.cxx
@@ -27,7 +27,7 @@
 #include "stir/DiscretisedDensity.h"
 #include "stir/VoxelsOnCartesianGrid.h"
 #include "stir/recon_buildblock/ProjMatrixElemsForOneBin.h"
-#include "stir/ViewSegmentNumbers.h"
+#include "stir/ViewSegmentTOFNumbers.h"
 #include "stir/RelatedViewgrams.h"
 //#include "stir/geometry/line_distances.h"
 #include "stir/Succeeded.h"

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -250,12 +250,12 @@ run() const
 		  // ** first fill in the data **      
 		  RelatedViewgrams<float> 
 			viewgrams = input_projdata.get_empty_related_viewgrams(view_seg_nums,symmetries_ptr,
-				false,timing_pos_num);
+				false);
 		  if (use_data_or_set_to_1)
 		  {
 			viewgrams += 
 			  input_projdata.get_related_viewgrams(view_seg_nums,
-							   symmetries_ptr,false,timing_pos_num);
+							   symmetries_ptr,false);
 		  }	  
 		  else
 		  {
@@ -273,14 +273,14 @@ run() const
 		  {
 			viewgrams += 
 			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false,timing_pos_num);
+													  symmetries_ptr,false);
 		  }
 
 		  if (do_randoms && apply_or_undo_correction)
 		  {
 			viewgrams -= 
 			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false,timing_pos_num);
+													  symmetries_ptr,false);
 		  }
 	#if 0
 		  if (frame_num==-1)
@@ -325,14 +325,14 @@ run() const
 		  {
 			viewgrams -= 
 			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false,timing_pos_num);
+													  symmetries_ptr,false);
 		  }
 
 		  if (do_randoms && !apply_or_undo_correction)
 		  {
 			viewgrams += 
 			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false,timing_pos_num);
+													  symmetries_ptr,false);
 		  }
 
 		  if (do_arc_correction && apply_or_undo_correction)
@@ -351,7 +351,7 @@ run() const
 		RelatedViewgrams<float> 
 		  output_viewgrams = 
 		  output_projdata.get_empty_related_viewgrams(view_seg_nums,
-								symmetries_ptr,false,timing_pos_num);
+								symmetries_ptr,false);
 		  output_viewgrams += viewgrams;
 
 		  if (!(output_projdata.set_related_viewgrams(viewgrams) == Succeeded::yes))

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -243,7 +243,7 @@ run() const
 		  cerr<<endl<<"Processing segment # "<<segment_num << "(and any related segments) of timing position index # "<<timing_pos_num <<endl;
 		for (int view_num=input_projdata.get_min_view_num(); view_num<=input_projdata.get_max_view_num(); ++view_num)
 		{    
-		  const ViewSegmentNumbers view_seg_nums(view_num,segment_num);
+		  const ViewSegmentTOFNumbers view_seg_nums(view_num,segment_num);
 		  if (!symmetries_ptr->is_basic(view_seg_nums))
 			continue;
       

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -249,13 +249,11 @@ run() const
       
 		  // ** first fill in the data **      
 		  RelatedViewgrams<float> 
-			viewgrams = input_projdata.get_empty_related_viewgrams(view_seg_nums,symmetries_ptr,
-				false);
+			viewgrams = input_projdata.get_empty_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  if (use_data_or_set_to_1)
 		  {
 			viewgrams += 
-			  input_projdata.get_related_viewgrams(view_seg_nums,
-							   symmetries_ptr,false);
+			  input_projdata.get_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  }	  
 		  else
 		  {
@@ -272,15 +270,13 @@ run() const
 		  if (do_scatter && !apply_or_undo_correction)
 		  {
 			viewgrams += 
-			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false);
+			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  }
 
 		  if (do_randoms && apply_or_undo_correction)
 		  {
 			viewgrams -= 
-			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false);
+			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  }
 	#if 0
 		  if (frame_num==-1)
@@ -324,15 +320,13 @@ run() const
 		  if (do_scatter && apply_or_undo_correction)
 		  {
 			viewgrams -= 
-			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false);
+			  scatter_projdata_ptr->get_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  }
 
 		  if (do_randoms && !apply_or_undo_correction)
 		  {
 			viewgrams += 
-			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums,
-													  symmetries_ptr,false);
+			  randoms_projdata_ptr->get_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  }
 
 		  if (do_arc_correction && apply_or_undo_correction)
@@ -349,9 +343,7 @@ run() const
 		// The trick relies on calling Array::operator+= instead of 
 		// RelatedViewgrams::operator=
 		RelatedViewgrams<float> 
-		  output_viewgrams = 
-		  output_projdata.get_empty_related_viewgrams(view_seg_nums,
-								symmetries_ptr,false);
+		  output_viewgrams = output_projdata.get_empty_related_viewgrams(view_seg_nums, symmetries_ptr);
 		  output_viewgrams += viewgrams;
 
 		  if (!(output_projdata.set_related_viewgrams(viewgrams) == Succeeded::yes))

--- a/src/utilities/correct_projdata.cxx
+++ b/src/utilities/correct_projdata.cxx
@@ -243,7 +243,7 @@ run() const
 		  cerr<<endl<<"Processing segment # "<<segment_num << "(and any related segments) of timing position index # "<<timing_pos_num <<endl;
 		for (int view_num=input_projdata.get_min_view_num(); view_num<=input_projdata.get_max_view_num(); ++view_num)
 		{    
-		  const ViewSegmentTOFNumbers view_seg_nums(view_num,segment_num);
+		  const ViewSegmentTOFNumbers view_seg_nums(view_num, segment_num, timing_pos_num);
 		  if (!symmetries_ptr->is_basic(view_seg_nums))
 			continue;
       


### PR DESCRIPTION
Hi @NikEfth,

I have started working on the STIR TOF branch and I have been trying to make some small changes to the branch to help clean it up. I think this is a logical change to the functionality. Please let me know if you have any comments etc. I began this branch looking to remove a single for loop and might have gotten slightly carried away. This will hopefully be useful for https://github.com/UCL/STIR/pull/304

The `ViewSegmentNumbers` are used in STIR as essentially indexing objects for particular viewgrams(?). There did appear to be some preperation to incorporate the TOF position numbers into this class. This PR completes that work and then extends the functionality to all classes which use the `ViewSegmentTOFNumbers` objects.

This affects all TOF aspects of STIR, e.g. `find_basic_vs_nums_in_subset`, which will now return a vector of `ViewSegmentTOFNumbers` objects that includes TOF position numbers. I have therefore removed a lot of the additonal `for` loops over TOF bins.

With regards to testing, I have:
 - Built STIR with this branch (with OpenMP, current fails without, which I am fixing.).
 - Tested reconstruction with OSMAPOSL (May be a preexisting bug with my D690 TOF reconstruction).

I did question if `ViewSegmentTimingNumbers` was a better class name than `ViewSegmentTOFNumbers`, but I thought that might get more confusing when considering other types of timing information, e.g. Gating.