### PR TITLE
Allow view_segment + TOF bin OpenMP

### DIFF
--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -200,11 +200,12 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
                                          subset_num, num_subsets);
 
 #ifdef STIR_OPENMP
-#pragma omp parallel shared(proj_data, symmetries_sptr)
-#endif
-  {
-#ifdef STIR_OPENMP
-#pragma omp for schedule(dynamic)
+  #if _OPENMP <201107
+    #pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)
+  #else
+    // OpenMP loop over both vs_nums_to_process and tof_pos_num
+    #pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic) collapse(2)
+  #endif
 #endif
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
@@ -228,7 +229,7 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
         back_project(viewgrams);
       }
   }
-  }
+
 #ifdef STIR_OPENMP
   // "reduce" data constructed by threads
   {

--- a/src/recon_buildblock/BackProjectorByBin.cxx
+++ b/src/recon_buildblock/BackProjectorByBin.cxx
@@ -210,12 +210,11 @@ BackProjectorByBin::back_project(const ProjData& proj_data, int subset_num, int 
     // note: older versions of openmp need an int as loop
     for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
       {
-        const ViewSegmentNumbers vs=vs_nums_to_process[i];
-
         for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
               k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
       		  ++k)
         {
+          const ViewSegmentNumbers vs=vs_nums_to_process[i];
 #ifdef STIR_OPENMP
         RelatedViewgrams<float> viewgrams;
 #pragma omp critical (BACKPROJECTORBYBIN_GETVIEWGRAMS)

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -205,11 +205,11 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)
     {
-      const ViewSegmentNumbers vs=vs_nums_to_process[i];
       for (int k=proj_data.get_proj_data_info_sptr()->get_min_tof_pos_num();
               k<=proj_data.get_proj_data_info_sptr()->get_max_tof_pos_num();
     		  ++k)
         {
+          const ViewSegmentNumbers vs=vs_nums_to_process[i];
           if (proj_data.get_proj_data_info_sptr()->is_tof_data())
             info(boost::format("Processing view %1% of segment %2% of TOF bin %3%") % vs.view_num() % vs.segment_num() % k);
     	  else

--- a/src/recon_buildblock/ForwardProjectorByBin.cxx
+++ b/src/recon_buildblock/ForwardProjectorByBin.cxx
@@ -195,7 +195,12 @@ ForwardProjectorByBin::forward_project(ProjData& proj_data,
                                          proj_data.get_min_segment_num(), proj_data.get_max_segment_num(),
                                          subset_num, num_subsets);
 #ifdef STIR_OPENMP
-#pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)
+  #if _OPENMP <201107
+    #pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic)
+  #else
+    // OpenMP loop over both vs_nums_to_process and tof_pos_num
+    #pragma omp parallel for  shared(proj_data, symmetries_sptr) schedule(dynamic) collapse(2)
+  #endif
 #endif
     // note: older versions of openmp need an int as loop
   for (int i=0; i<static_cast<int>(vs_nums_to_process.size()); ++i)

--- a/src/recon_buildblock/distributable.cxx
+++ b/src/recon_buildblock/distributable.cxx
@@ -431,7 +431,12 @@ void distributable_computation(
       local_counts.resize(omp_get_max_threads(), 0);
       local_count2s.resize(omp_get_max_threads(), 0);
     }
-#pragma omp for schedule(dynamic)  
+ #if _OPENMP <201107
+  #pragma omp for schedule(dynamic)
+ #else
+    // OpenMP loop over both vs_nums_to_process and tof_pos_num
+    #pragma omp for schedule(dynamic) collapse(2)
+  #endif
 #endif
 
   for (int timing_pos_num = min_timing_pos_num; timing_pos_num <= max_timing_pos_num; ++timing_pos_num)


### PR DESCRIPTION
Partially addresses #21 
~~Switch distributable `for` loop order to perform OpenMP over the `vs_nums_to_process` rather than TOF bins.~~
Edit: Implements a collapse to allow OpenMP to iterate over both the `vs_nums_to_process` and TOF bin `for` loops.
This should accelerate general reconstructions but this is a "quick fix" and not desired long term behaviour. A #17 type fix is a long term plan.
