### PR TITLE
fix TOF get_det_pos_pair_for_bin and other swapping problems

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,12 @@ on:
     branches:
       - master
       - tof_sino_UCL
-
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+        required: false
+        default: false
 jobs:
   build:
 
@@ -41,13 +46,15 @@ jobs:
         - os: macOS-latest
           compiler: gcc
           compiler_version: 11
-          BUILD_FLAGS: "-DSTIR_OPENMP=ON"
-          BUILD_TYPE: "Release"
+          BUILD_FLAGS: "-DSTIR_OPENMP=OFF"
+          BUILD_TYPE: "Debug"
           parallelproj: "OFF"
           ROOT: "OFF"
 
       # let's run all of them, as opposed to aborting when one fails
       fail-fast: false
+
+    name: ${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}-pp=${{ matrix.parallelproj }}-ROOT=${{ matrix.ROOT }}
 
     steps:
     - uses: actions/checkout@v2
@@ -180,6 +187,7 @@ jobs:
           echo CMAKE_INSTALL_PREFIX="$CMAKE_INSTALL_PREFIX" >> $GITHUB_ENV
           EXTRA_BUILD_FLAGS="-DBUILD_SWIG_PYTHON=ON -DPYTHON_EXECUTABLE=`which python`"
           EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=${BUILD_TYPE}"
+          EXTRA_BUILD_FLAGS="${EXTRA_BUILD_FLAGS} -DDOWNLOAD_ZENODO_TEST_DATA=ON"
           echo "cmake flags $BUILD_FLAGS $EXTRA_BUILD_FLAGS"          
           mkdir build
           cd build
@@ -202,7 +210,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           # don't run all of them in Debug mode as it takes too long
           if test ${BUILD_TYPE} = Debug; then
-              EXCLUDE="-E test_data_processor_projectors -E test_export_array -E test_ArcCorrection"
+              EXCLUDE="-E test_data_processor_projectors|test_export_array|test_ArcCorrection|test_blocks_on_cylindrical_projectors"
           fi
           ctest --output-on-failure -C ${BUILD_TYPE} ${EXCLUDE}
 
@@ -229,6 +237,20 @@ jobs:
             cd ${GITHUB_WORKSPACE}/recon_test_pack/SPECT
             ./run_SPECT_tests.sh
           fi
+
+    - name: Upload log files for debugging
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: recon_test_pack_log_files-${{ matrix.os }}-${{ matrix.compiler }}${{ matrix.compiler_version }}-${{ matrix.BUILD_TYPE }}-pp=${{ matrix.parallelproj }}-ROOT=${{ matrix.ROOT }}
+        path: ${{ github.workspace }}/recon_test_pack/**/*.log
+        retention-days: 7
+
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session if triggered
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
 
     - name: examples
       shell: bash

--- a/documentation/release_notes_TOF.htm
+++ b/documentation/release_notes_TOF.htm
@@ -1,0 +1,131 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <head>
+    <title>Summary of changes in STIR release 6.0</title>
+  </head>
+
+  <body>
+    <h1>Summary of changes in STIR release 6.0</h1>
+
+<p>This version is 95% backwards compatible with STIR 4.0 for the user (see below).
+Developers might need to make code changes as 
+detailed below.
+</p>
+<h2>Overall summary</h2>
+<p>
+</p>
+
+
+<p>Of course, there is also the usual code-cleanup and 
+improvements to the documentation.
+</p>
+
+<p>This release contains mainly code written by Kris Thielemans (UCL)  and Richard Brown (UCL).
+</p>
+
+    <h2>Patch release info</h2>
+    <ul>
+      <li> 5.0.0 released ?/?/2020</li>
+      <!--
+      <li> 4.0.1 released 28/04/2020
+        <ul>
+          <li><a href=https://github.com/UCL/STIR/pull/513>PR 513</a>  (suppress warnings with clang)</li>
+          </ul>
+          -->
+    </ul>
+
+<h2> Summary for end users (also to be read by developers)</h2>
+
+<h3>Changes breaking backwards compatibility from a user-perspective</h3>
+<ul>
+  <li> </li>
+  <ul>
+
+
+<h3>Bug fixes</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+<h3>New functionality</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+
+<h3>Changed functionality</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+
+<h3>Build system</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+
+<h3>Known problems</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+<h3>Minor bug fixes</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+<h3>Documentation changes</h3>
+<ul>
+<li>Added documentation on new features</li> 
+<li>Also check the wiki in addition to the provided PDFs.
+</li>
+ </ul>
+
+<h3>recon_test_pack changes</h3>
+<ul>
+<li>updated version number and added some clarification to the README.txt</li>
+ </ul>
+
+<h3>Other changes to tests</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+<H2>What's new for developers (aside from what should be obvious
+from the above):</H2>
+
+<h3>Major bugs fixed</h3>
+<ul>
+<li>see above</li>
+</ul>
+
+<h3>Backward incompatibities</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+<h3>New functionality</h3>
+<ul>
+  <li><code>Bin</code> can now be output to stream as text</li>
+  <li>added <code>RunTests::check_if_equal</code> for <code>Bin</code></li>
+</ul>
+
+
+<h3>Other code changes</h3>
+<ul>
+<li>
+</li>
+</ul>
+
+</body>
+
+</html>

--- a/src/buildblock/ProjDataInfoCylindrical.cxx
+++ b/src/buildblock/ProjDataInfoCylindrical.cxx
@@ -580,6 +580,9 @@ get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor,
                  false);// needs to set "swapped" to false given above code 
 }  
 
+#if 0
+  // KT disabled these as untested (and unused)
+
 void
 ProjDataInfoCylindrical::
 get_LOR_as_two_points(CartesianCoordinate3D<float>& coord_1,
@@ -650,6 +653,7 @@ get_LOR_as_two_points_alt(CartesianCoordinate3D<float>& coord_1,
 	if (timing_pos<0)
 		std::swap(coord_1, coord_2);
 }
+#endif
 
 string
 ProjDataInfoCylindrical::parameter_info()  const

--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -549,42 +549,6 @@ find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<floa
     std::swap(coord_1, coord_2);
 }
 
-
-//! \obsolete I don't see any reason why to keep having this function.
-void
-ProjDataInfoCylindricalNoArcCorr::
-find_cartesian_coordinates_given_scanner_coordinates_of_the_front_surface (
-        CartesianCoordinate3D<float>& coord_1,
-        CartesianCoordinate3D<float>& coord_2,
-        const int Ring_A,const int Ring_B,
-        const int det1, const int det2) const
-{
-    const int num_detectors_per_ring =
-            get_scanner_ptr()->get_num_detectors_per_ring();
-
-//    float h_scanner_height = ( (get_scanner_ptr()->get_ring_spacing() -1) * get_scanner_ptr()->get_num_rings())/2.F;
-
-    // although code maybe doesn't really need the following,
-    // asserts in the LOR code will break if these conditions are not satisfied.
-    assert(0<=det1);
-    assert(det1<num_detectors_per_ring);
-    assert(0<=det2);
-    assert(det2<num_detectors_per_ring);
-
-    LORInCylinderCoordinates<float> cyl_coords(get_scanner_ptr()->get_inner_ring_radius());
-
-    cyl_coords.p1().psi() = static_cast<float>((2.*_PI/num_detectors_per_ring)*(det1));
-    cyl_coords.p2().psi() = static_cast<float>((2.*_PI/num_detectors_per_ring)*(det2));
-
-//    cyl_coords.p1().z() = Ring_A*get_scanner_ptr()->get_ring_spacing() - h_scanner_height;
-//    cyl_coords.p2().z() = Ring_B*get_scanner_ptr()->get_ring_spacing() - h_scanner_height;
-
-    LORAs2Points<float> lor(cyl_coords);
-    coord_1 = lor.p1();
-    coord_2 = lor.p2();
-}
-
-
 void 
 ProjDataInfoCylindricalNoArcCorr::
 find_bin_given_cartesian_coordinates_of_detection(Bin& bin,

--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -473,16 +473,18 @@ find_cartesian_coordinates_of_detection(
 					const Bin& bin) const
 {
  // find detectors
-  int det_num_a;
-  int det_num_b;
-  int ring_a;
-  int ring_b;
-  get_det_pair_for_bin(det_num_a, ring_a,
-                       det_num_b, ring_b, bin);
+  DetectionPositionPair<> dpp;
+  get_det_pos_pair_for_bin(dpp, bin);
   
+  /* TODO
+   best to use Scanner::get_coordinate_for_det_pos().
+   Sadly, the latter is not yet implemented for Cylindrical scanners.
+  */
   // find corresponding cartesian coordinates
   find_cartesian_coordinates_given_scanner_coordinates(coord_1,coord_2,
-    ring_a,ring_b,det_num_a,det_num_b);
+                                                       dpp.pos1().axial_coord(), dpp.pos2().axial_coord(),
+                                                       dpp.pos1().tangential_coord(), dpp.pos2().tangential_coord(),
+                                                       dpp.timing_pos());
 }
 
 
@@ -491,7 +493,7 @@ ProjDataInfoCylindricalNoArcCorr::
 find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<float>& coord_1,
 				 CartesianCoordinate3D<float>& coord_2,
 				 const int Ring_A,const int Ring_B, 
-				 const int det1, const int det2) const
+                                 const int det1, const int det2, const int timing_pos_num) const
 {
   const int num_detectors_per_ring = 
     get_scanner_ptr()->get_num_detectors_per_ring();
@@ -543,6 +545,8 @@ find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<floa
   coord_2 = lor.p2();
   
 #endif
+  if (timing_pos_num < 0)
+    std::swap(coord_1, coord_2);
 }
 
 

--- a/src/experimental/test/test_proj_data_info_LOR.cxx
+++ b/src/experimental/test/test_proj_data_info_LOR.cxx
@@ -161,7 +161,8 @@ main(int argc,char *argv[])
 
        proj_data_cyl_no_arc_ptr->find_cartesian_coordinates_given_scanner_coordinates (coord_1_90,coord_2_90,
 										       ring1_90,ring2_90, 
-										       det1_90, det2_90);
+										       det1_90, det2_90,
+                                                                                       0); // set timing_pos_num=0 as test-code is pre-TOF
 
 #if 0
        cout << coord_1_0<<endl;

--- a/src/include/stir/Bin.h
+++ b/src/include/stir/Bin.h
@@ -36,17 +36,14 @@ START_NAMESPACE_STIR
  \brief
  A class for storing coordinates and value of a single projection bin.
 
- The timing position reflect the detection time difference between the two events.
- It is a multiple of the delta t of the least significant clock bit.
+ The timing position reflects the detection time difference between the two events for TOF.
+ It is an "index" into the projection data like the other values.
 
  The \c time_frame member defaults to 1 and needs to be set explicitly, e.g. when
  handling list mode data.
 
  \warning N.E: Constructors with default values were removed. I faced many problems with ambguity. I had to make
  changes to all the framework, when one set a float value, it has to be as 'x.f'
-
- \warning Temporarily the timing_pos_num is not taken into account when comparing two bins,
-    Until were are actually able to cache LORs based on timing location this could be let off.
 */
 
 class Bin

--- a/src/include/stir/Bin.inl
+++ b/src/include/stir/Bin.inl
@@ -27,7 +27,7 @@
 START_NAMESPACE_STIR
 
 Bin::Bin():segment(0),view(0),
-    axial_pos(0),tangential_pos(0),timing_pos(0), bin_value(0.0f)
+    axial_pos(0),tangential_pos(0),timing_pos(0), bin_value(0.0f),time_frame(1)
 {}
 
 
@@ -48,7 +48,7 @@ Bin::Bin(int segment_num,int view_num, int axial_pos_num,int tangential_pos_num,
 
 Bin::Bin(int segment_num,int view_num, int axial_pos_num,int tangential_pos_num, int  timing_pos_num)
      :segment(segment_num),view(view_num),
-     axial_pos(axial_pos_num),tangential_pos(tangential_pos_num), timing_pos(timing_pos_num), bin_value(0.0f)
+      axial_pos(axial_pos_num),tangential_pos(tangential_pos_num), timing_pos(timing_pos_num), bin_value(0.0f), time_frame(1)
      {}
 
      
@@ -138,6 +138,7 @@ Bin::operator==(const Bin& bin2) const
     segment == bin2.segment && view == bin2.view && 
     axial_pos == bin2.axial_pos && tangential_pos == bin2.tangential_pos &&
     timing_pos == bin2.timing_pos &&
+    time_frame == bin2.time_frame &&
     bin_value == bin2.bin_value;
 }
 

--- a/src/include/stir/DetectionPositionPair.h
+++ b/src/include/stir/DetectionPositionPair.h
@@ -42,11 +42,11 @@ public:
   
   inline DetectionPositionPair(const DetectionPosition<coordT>&, 
                                const DetectionPosition<coordT>&,
-                               const coordT timing_pos = static_cast<coordT>(0));
+                               const int timing_pos = 0);
   
   inline const DetectionPosition<coordT>& pos1() const;   
   inline const DetectionPosition<coordT>& pos2() const;
-  inline const coordT timing_pos() const;
+  inline int timing_pos() const;
   inline DetectionPosition<coordT>& pos1();   
   inline DetectionPosition<coordT>& pos2();
   inline int& timing_pos();

--- a/src/include/stir/DetectionPositionPair.inl
+++ b/src/include/stir/DetectionPositionPair.inl
@@ -22,14 +22,14 @@ START_NAMESPACE_STIR
 template <typename coordT>
 DetectionPositionPair<coordT>::
 DetectionPositionPair()
-  : _timing_pos(static_cast<coordT>(0))
+  : _timing_pos(0)
 {}
 
 template <typename coordT>
 DetectionPositionPair<coordT>::
 DetectionPositionPair(const DetectionPosition<coordT>& pos1,
                       const DetectionPosition<coordT>& pos2,
-					  const coordT timing_pos)
+                      const int timing_pos)
   : p1(pos1), p2(pos2), _timing_pos(timing_pos)
 {}
 
@@ -46,7 +46,7 @@ pos2() const
 { return p2; }
 
 template <typename coordT>
-const coordT
+int
 DetectionPositionPair<coordT>::
 timing_pos() const
 { return _timing_pos; }
@@ -76,12 +76,7 @@ DetectionPositionPair<coordT>::
 operator==(const DetectionPositionPair& p) const
 {
   // Slightly complicated as we need to be able to cope with reverse order of detectors. If so,
-  // the TOF bin should swap as well. However, currently, coordT is unsigned, so timing_pos is
-  // always positive so sign reversal can never occur. Below implementation is ok, but
-  // generates a compiler warning on many compilers for unsigned.
-  // For an unsigned type, we should check
-  //    timing_pos() == coordT(0) && p.timing_pos()  == coordT(0)
-  // TODO. differentiate between types
+  // the TOF bin should swap as well.
   return 
     (pos1() == p.pos1() && pos2() == p.pos2() && timing_pos() == p.timing_pos()) ||
     (pos1() == p.pos2() && pos2() == p.pos1() && timing_pos() == -p.timing_pos());

--- a/src/include/stir/ProjDataInfoCylindrical.h
+++ b/src/include/stir/ProjDataInfoCylindrical.h
@@ -90,6 +90,8 @@ public:
   virtual void
     get_LOR(LORInAxialAndNoArcCorrSinogramCoordinates<float>& lor,
 	    const Bin& bin) const;
+#if 0
+  // KT disabled these as untested (and unused)
 
   //! This function returns the two points connecting the two detectors of the LOR.
   //!  \warning there is not a specific guarantee that these are going to be the two
@@ -109,7 +111,7 @@ public:
                             const int ring1,
                             const int ring2,
                             const int timing_pos) const;
- 
+#endif
   //! Set azimuthal angle offset (in radians)
   void set_azimuthal_angle_offset(const float angle);
   //! Set the azimuthal sampling (in radians)

--- a/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
@@ -280,7 +280,8 @@ public:
   void find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<float>& coord_1,
 							     CartesianCoordinate3D<float>& coord_2,
 							     const int Ring_A,const int Ring_B, 
-							     const int det1, const int det2) const;
+							     const int det1, const int det2,
+                                                             const int timing_pos_num) const;
  
   void find_bin_given_cartesian_coordinates_of_detection(Bin& bin,
 						  const CartesianCoordinate3D<float>& coord_1,

--- a/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
+++ b/src/include/stir/ProjDataInfoCylindricalNoArcCorr.h
@@ -267,11 +267,6 @@ public:
   Succeeded find_scanner_coordinates_given_cartesian_coordinates(int& det1, int& det2, int& ring1, int& ring2,
 					             const CartesianCoordinate3D<float>& c1,
 						     const CartesianCoordinate3D<float>& c2) const;
-
-  void find_cartesian_coordinates_given_scanner_coordinates_of_the_front_surface(CartesianCoordinate3D<float>& coord_1,
-                                                                                 CartesianCoordinate3D<float>& coord_2,
-                                                                                 const int Ring_A,const int Ring_B,
-                                                                                 const int det1, const int det2) const;
   
   void find_cartesian_coordinates_of_detection(CartesianCoordinate3D<float>& coord_1,
 					       CartesianCoordinate3D<float>& coord_2,

--- a/src/include/stir/ProjDataInfoCylindricalNoArcCorr.inl
+++ b/src/include/stir/ProjDataInfoCylindricalNoArcCorr.inl
@@ -183,27 +183,29 @@ get_det_pos_pair_for_bin(
              DetectionPositionPair<>& dp,
              const Bin& bin) const
 {
-  //lousy work around because types don't match TODO remove!
-#if 1
-  int t1=dp.pos1().tangential_coord(),
-    a1=dp.pos1().axial_coord(),
-    t2=dp.pos2().tangential_coord(),
-    a2=dp.pos2().axial_coord();
+  // This is a bit complicated as DetectionPositionPair<>::timing_pos() is an unsigned int,
+  // while Bin uses an int. So we need to swap detectors around.
+
+  //lousy work around because types don't match (short/int). TODO remove!
+  int t1, a1, t2, a2;
   get_det_pair_for_bin(t1, a1, t2, a2, bin);
-  dp.pos1().tangential_coord()=t1;
-  dp.pos1().axial_coord()=a1;
-  dp.pos2().tangential_coord()=t2;
-  dp.pos2().axial_coord()=a2;
+  if (bin.timing_pos_num()>=0)
+    {
+      dp.pos1().tangential_coord()=t1;
+      dp.pos1().axial_coord()=a1;
+      dp.pos2().tangential_coord()=t2;
+      dp.pos2().axial_coord()=a2;
+    }
+  else
+    {
+      dp.pos1().tangential_coord()=t2;
+      dp.pos1().axial_coord()=a2;
+      dp.pos2().tangential_coord()=t1;
+      dp.pos2().axial_coord()=a1;
+    }
+    
   dp.timing_pos() = std::abs(bin.timing_pos_num())*this->get_tof_mash_factor();
 
-#else
-
-  get_det_pair_for_bin(dp.pos1().tangential_coord(),
-                       dp.pos1().axial_coord(),
-               dp.pos2().tangential_coord(),
-                       dp.pos2().axial_coord(),
-                       bin);
-#endif
 }
 
 END_NAMESPACE_STIR

--- a/src/include/stir/ProjDataInfoCylindricalNoArcCorr.inl
+++ b/src/include/stir/ProjDataInfoCylindricalNoArcCorr.inl
@@ -183,8 +183,8 @@ get_det_pos_pair_for_bin(
              DetectionPositionPair<>& dp,
              const Bin& bin) const
 {
-  // This is a bit complicated as DetectionPositionPair<>::timing_pos() is an unsigned int,
-  // while Bin uses an int. So we need to swap detectors around.
+  // This is a bit complicated as DetectionPositionPair<>::timing_pos() was an unsigned int at some point,
+  // while Bin uses an int. So swap detectors around.
 
   //lousy work around because types don't match (short/int). TODO remove!
   int t1, a1, t2, a2;

--- a/src/include/stir/RunTests.h
+++ b/src/include/stir/RunTests.h
@@ -2,7 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000-2005, Hammersmith Imanet Ltd
     Copyright (C) 2013, Kris Thielemans
-    Copyright (C) 2013, 2020 University College London
+    Copyright (C) 2013, 2020, 2022 University College London
     Copyright (C) 2018, University of Hull
     This file is part of STIR.
 
@@ -25,6 +25,7 @@
 #include "stir/BasicCoordinate.h"
 #include "stir/IndexRange.h"
 #include "stir/stream.h"
+#include "stir/Bin.h"
 #include <iostream>
 #include <typeinfo>
 #include <vector>
@@ -116,6 +117,9 @@ public:
   bool check_if_equal(const long long a, const long long b, const std::string& str = "");
   bool check_if_equal(const unsigned long long a, const unsigned long long b, const std::string& str = "");
 #endif
+  bool check_if_equal(const Bin& a, const Bin& b, const std::string& str = "")
+  {  return this->check_if_equal_generic(a,b,str);}
+
   // VC 6.0 needs definition of template members in the class def unfortunately.
   //! check equality by calling check_if_equal on real and imaginary parts
   template <class T>

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithDiscreteDetectors.inl
@@ -6,10 +6,13 @@
   \brief Implementations of class stir::CListEventCylindricalScannerWithDiscreteDetectors
 
   \author Kris Thielemans
-
+  \author Nikos Efthimiou
+  \author Elise Emond
 */
 /*
     Copyright (C) 2003- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2017, 2022, University College London
+    Copyright (C) 2017, University of Leeds
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -27,7 +30,7 @@ CListEventCylindricalScannerWithDiscreteDetectors(const shared_ptr<const ProjDat
     this->uncompressed_proj_data_info_sptr = std::dynamic_pointer_cast< const ProjDataInfoCylindricalNoArcCorr >(proj_data_info_sptr->create_shared_clone());
 
     if (is_null_ptr(this->uncompressed_proj_data_info_sptr))
-        error("CListEventCylindricalScannerWithDiscreteDetectors takes only ProjDataInfoCylindricalNoArcCorr. Abord.");
+        error("CListEventCylindricalScannerWithDiscreteDetectors takes only ProjDataInfoCylindricalNoArcCorr. Abort.");
 }
 
 LORAs2Points<float>
@@ -35,9 +38,10 @@ CListEventCylindricalScannerWithDiscreteDetectors::
 get_LOR() const
 {
   LORAs2Points<float> lor;
-  // provide somewhat shorter names for the 2 coordinates
-  CartesianCoordinate3D<float>& coord_1 = lor.p1();
-  CartesianCoordinate3D<float>& coord_2 = lor.p2();
+  bool swap = this->get_delta_time() < 0.F;
+  // provide somewhat shorter names for the 2 coordinates, taking swap into account
+  CartesianCoordinate3D<float>& coord_1 = swap ? lor.p2() : lor.p1();
+  CartesianCoordinate3D<float>& coord_2 = swap ? lor.p1() : lor.p2();
 
   DetectionPositionPair<> det_pos;
   this->get_detection_position(det_pos);
@@ -50,7 +54,8 @@ get_LOR() const
                                                          det_pos.pos1().axial_coord(),
                                                          det_pos.pos2().axial_coord(),
                                                          det_pos.pos1().tangential_coord(),
-                                                         det_pos.pos2().tangential_coord());
+                                                         det_pos.pos2().tangential_coord(),
+                                                         det_pos.timing_pos());
   // find shift in z
   const float shift = this->get_uncompressed_proj_data_info_sptr()->get_ring_spacing()*
     (this->get_uncompressed_proj_data_info_sptr()->get_scanner_ptr()->get_num_rings()-1)/2.F;

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.h
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.h
@@ -85,8 +85,6 @@ public CListEventCylindricalScannerWithDiscreteDetectors
    */
   inline virtual bool is_valid_template(const ProjDataInfo&) const;
 
-  inline void get_uncompressed_bin(Bin& bin) const;
-
 };
 
 END_NAMESPACE_STIR

--- a/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.inl
+++ b/src/include/stir/listmode/CListEventCylindricalScannerWithViewTangRingRingEncoding.inl
@@ -2,6 +2,7 @@
 //
 /*
     Copyright (C) 2003- 2011, Hammersmith Imanet Ltd
+    Copyright (C) 2018, 2022, University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0
@@ -14,6 +15,8 @@
   \brief Implementation for stir::CListEventCylindricalScannerWithViewTangRingRingEncoding
     
   \author Kris Thielemans
+  \author Elise Emond
+  \author Nikos Efthimiou
       
 */
 
@@ -70,6 +73,8 @@ set_detection_position(const DetectionPositionPair<>& det_pos)
                                       det_pos.pos2().axial_coord(),
                                       det_pos.pos1().axial_coord());
   }
+  if (this->get_uncompressed_proj_data_info_sptr()->is_tof_data())
+    error("TODO: CListEventCylindricalScannerWithViewTangRingRingEncoding::set_detection_position needs to be implemented for TOF");
 }
 
 static void
@@ -103,8 +108,7 @@ get_bin(Bin& bin, const ProjDataInfo& proj_data_info) const
     get_sinogram_and_ring_coordinates(view_num, tangential_pos_num, ring_a, ring_b);
   sinogram_coordinates_to_bin(bin, view_num, tangential_pos_num, ring_a, ring_b, 
 			      static_cast<const ProjDataInfoCylindrical&>(proj_data_info));
-  if (proj_data_info.get_num_tof_poss() > 1)
-      bin.timing_pos_num() = proj_data_info.get_tof_bin(delta_time);
+  bin.timing_pos_num() = proj_data_info.get_tof_bin(delta_time);
 }
 
 template <class Derived>
@@ -117,18 +121,5 @@ is_valid_template(const ProjDataInfo& proj_data_info) const
 
 	return false;
 }
-
-template <class Derived>
-void 
-CListEventCylindricalScannerWithViewTangRingRingEncoding<Derived>::
-get_uncompressed_bin(Bin& bin) const
-{
-  unsigned int ring_a;
-  unsigned int ring_b;
-  this->get_sinogram_and_ring_coordinates(bin.view_num(), bin.tangential_pos_num(), ring_a, ring_b);
-  this->get_uncompressed_proj_data_info_sptr()->
-    get_segment_axial_pos_num_for_ring_pair(bin.segment_num(), bin.axial_pos_num(), 
-					    ring_a, ring_b);
-}  
   
 END_NAMESPACE_STIR

--- a/src/include/stir/listmode/CListRecord.h
+++ b/src/include/stir/listmode/CListRecord.h
@@ -57,19 +57,10 @@ public:
     Succeeded
     set_prompt(const bool prompt = true);
 
-    //! Returns true is the delta_time has been swapped.
-    bool
-    get_swapped() const
-    {return swapped;}
-
     double get_delta_time() const { return delta_time; }
 protected:
     //! The detection time difference, between the two photons.
-    //! This will work for ROOT files, but not so sure about acquired data.
     double delta_time;
-
-    //! Indicates if the detectors' order has been swapped.
-    bool swapped;
 
 }; /*-coincidence event*/
 

--- a/src/include/stir/listmode/CListRecordROOT.h
+++ b/src/include/stir/listmode/CListRecordROOT.h
@@ -50,9 +50,6 @@ public:
     inline bool is_prompt() const
     { return true; }
 
-    bool inline is_swapped() const
-    { return swapped; }
-
 private:
     //! First ring, in order to detector tangestial index
     int ring1;
@@ -62,8 +59,6 @@ private:
     int det1;
     //! Second detector, in order to detector tangestial index
     int det2;
-    //! Indicates if swap segments
-    bool swapped;
 #ifdef STIR_ROOT_ROTATION_AS_V4
     //! This is the number of detector we have to rotate in order to
     //! align GATE and STIR.

--- a/src/include/stir/listmode/ListEvent.h
+++ b/src/include/stir/listmode/ListEvent.h
@@ -60,6 +60,9 @@ public:
       Coordinates are in mm and in the standard STIR coordinate system
       used by ProjDataInfo etc (i.e. origin is in the centre of the scanner).
 
+      Note that for PET data, this (should) return a "directed" LOR. e.g.
+      if the TOF bin changes sign, the coordinates will swap.
+
       \todo This function might need time info or so for rotating scanners.
   */
   virtual LORAs2Points<float>

--- a/src/include/stir/stream.h
+++ b/src/include/stir/stream.h
@@ -26,6 +26,7 @@
 
 #include "stir/VectorWithOffset.h"
 #include "stir/BasicCoordinate.h"
+#include "stir/Bin.h"
 #include <iostream>
 #include <vector>
 
@@ -80,6 +81,15 @@ template <typename elemT>
 inline 
 std::ostream& 
 operator<<(std::ostream& str, const std::vector<elemT>& v);
+
+inline std::ostream& operator<<(std::ostream& out, const Bin& bin)
+{
+  return out << "[segment_num=" << bin.segment_num() << ", axial_pos_num=" << bin.axial_pos_num()
+             << ", view_num=" << bin.view_num() << ", tangential_pos_num=" << bin.tangential_pos_num()
+             << ", timing_pos_num=" << bin.timing_pos_num()
+             << ", time_frame_num=" << bin.time_frame_num()
+             << ", value=" << bin.get_bin_value() << "]";
+}
 
 /*!
   \brief Inputs a vector from a stream.

--- a/src/listmode_buildblock/CListRecordROOT.cxx
+++ b/src/listmode_buildblock/CListRecordROOT.cxx
@@ -88,7 +88,6 @@ void CListEventROOT::init_from_data(const int& _ring1, const int& _ring2,
     ring1 = _ring1;
     ring2 = _ring2;
     delta_time = _delta_time;
-    swapped = false;
 }
 
 END_NAMESPACE_STIR

--- a/src/test/test_proj_data_info.cxx
+++ b/src/test/test_proj_data_info.cxx
@@ -1440,7 +1440,7 @@ ProjDataInfoCylindricalNoArcCorrTests::test_proj_data_info(ProjDataInfoCylindric
                 CartesianCoordinate3D<float> coord_1;
                 CartesianCoordinate3D<float> coord_2;
 
-                proj_data_info.find_cartesian_coordinates_given_scanner_coordinates(coord_1, coord_2, Ring_A, Ring_B, det1, det2);
+                proj_data_info.find_cartesian_coordinates_given_scanner_coordinates(coord_1, coord_2, Ring_A, Ring_B, det1, det2, 1); // use timing_pos_num>=0 as pre-TOF test
 
                 const CartesianCoordinate3D<float> coord_1_new = coord_1 + (coord_2 - coord_1) * 5;
                 const CartesianCoordinate3D<float> coord_2_new = coord_1 + (coord_2 - coord_1) * 2;


### PR DESCRIPTION
ProjdataInfoCylindricalNoArccorr::get_det_pos_pair_for_bin forgot to swap detectors for a negative TOF bin.

Somewhat amazingly, the GATE test (and all others) seem still to work.

Fixes https://github.com/NikEfth/STIR/issues/26

@robbietuk, @ashgillman, @NikEfth maybe you have a quick look.
@nicolejurjew, @ALEXJAZZ008008 could you check if this changes your simulation results? Same for reconstruction of course.