### PR TITLE
ProjDataFromStream offsets refactor

### DIFF
--- a/src/buildblock/ProjDataInMemory.cxx
+++ b/src/buildblock/ProjDataInMemory.cxx
@@ -167,8 +167,7 @@ float
 ProjDataInMemory::get_bin_value(Bin& bin)
 {
   // first find offset in the stream
-  std::vector<std::streamoff> offsets = get_offsets_bin(bin);
-  const std::streamoff total_offset = offsets[0];
+  const std::streamoff total_offset = get_offset(bin);
   // now convert to index in the buffer
   const int index = static_cast<int>(total_offset/sizeof(float));
   return buffer[index];
@@ -178,8 +177,7 @@ void
 ProjDataInMemory::set_bin_value(const Bin& bin)
 {
   // first find offset in the stream
-  std::vector<std::streamoff> offsets = get_offsets_bin(bin);
-  const std::streamoff total_offset = offsets[0];
+  const std::streamoff total_offset = get_offset(bin);
   // now convert to index in the buffer
   const int index = static_cast<int>(total_offset/sizeof(float));
   

--- a/src/include/stir/ProjDataFromStream.h
+++ b/src/include/stir/ProjDataFromStream.h
@@ -18,6 +18,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000- 2013, Hammersmith Imanet Ltd
     Copyright (C) 2016, University of Hull
+    Copyright (C) 2020, 2022 University College London
 
     This file is part of STIR.
 
@@ -59,8 +60,9 @@ public:
 
   enum StorageOrder {
     Segment_AxialPos_View_TangPos,
-      Segment_View_AxialPos_TangPos,
-      Timing_Segment_View_AxialPos_TangPos,
+    Timing_Segment_AxialPos_View_TangPos,
+    Segment_View_AxialPos_TangPos,
+    Timing_Segment_View_AxialPos_TangPos,
     Unsupported };
 #if 0    
   static  ProjDataFromStream* ask_parameters(const bool on_disk = true);
@@ -158,8 +160,9 @@ protected:
   //! the stream with the data
   shared_ptr<std::iostream> sino_stream;
 
-  //! Calculate the offsets for specific bins.
-  std::vector<std::streamoff> get_offsets_bin(const Bin) const;
+  //! Calculate the offset for a specific bin
+  /*! Throws if out-of-range or other error */
+  std::streamoff get_offset(const Bin&) const;
 
 private:
 
@@ -187,23 +190,6 @@ private:
   // memory as float, with the scale factor multiplied out
   float scale_factor;
 
-  //! Calculate the offset of the give timing position
-  //! \warning N.E: This function might be one the major components of STIR's speeds
-  std::streamoff get_offset_timing(const int timing_num) const;
-  
-  //! Calculate the offset for the given segmnet
-  //! \warning This function returns the offset of a segment *WITHING* a timing position
-  //! If you like to get the offset of a segment from different timing positions it has to
-  //! be combined with get_offset_timing().
-  std::streamoff get_offset_segment(const int segment_num) const;
-  
-  //! Calculate offsets for viewgram data  
-  std::vector<std::streamoff> get_offsets(const int view_num, const int segment_num,
-                                          const int timing_num = 0) const;
-  //! Calculate offsets for sinogram data
-  std::vector<std::streamoff> get_offsets_sino(const int ax_pos_num, const int segment_num,
-                                               const int timing_num = 0) const;
-    
 private:
 #if __cplusplus > 199711L
   ProjDataFromStream& operator=(ProjDataFromStream&&) = delete;

--- a/src/test/test_proj_data.cxx
+++ b/src/test/test_proj_data.cxx
@@ -148,9 +148,8 @@ run_tests_on_proj_data(ProjData& proj_data)
   }
   timer.stop(); std::cerr<< "-- CPU Time " << timer.value() << '\n';
 
-  std::cerr << "\ntest copy_to order (non-TOF)\n";
+  std::cerr << "\ntest copy_to order\n";
   timer.reset(); timer.start();
-  if (proj_data.get_num_tof_poss() == 1) // currently fails with TOF, so only run in non-TOF case
   {
     Array<4,float> test_array(IndexRange4D(proj_data.get_min_tof_pos_num(), proj_data.get_max_tof_pos_num(),
                                            0, proj_data.get_num_non_tof_sinograms()-1,
@@ -158,10 +157,9 @@ run_tests_on_proj_data(ProjData& proj_data)
                                            proj_data.get_min_tangential_pos_num(), proj_data.get_max_tangential_pos_num()));
     // copy to the array
     copy_to(proj_data, test_array.begin_all());
-    int total_ax_pos_num = 0;
     for (int k=proj_data.get_min_tof_pos_num(); k<=proj_data.get_max_tof_pos_num(); ++k)
       {
-
+        int total_ax_pos_num = 0;
         for (int segment_num : proj_data.standard_segment_sequence(*proj_data.get_proj_data_info_sptr()))
           {
             for (int ax_pos_num=proj_data.get_min_axial_pos_num(segment_num); ax_pos_num<=proj_data.get_max_axial_pos_num(segment_num); ++ax_pos_num, ++total_ax_pos_num)


### PR DESCRIPTION
Rework of the offset determination in `ProjDataFromStream`, using a single `get_offset(Bin)` function. This then made it easy to support the "missing" order timing/segment/axialpos/view/tangpos. Luckily, this made the code simpler.

Also fix the `recon_test_pack` for TOF, as the read function now explicitly failed when multiplying the TOF-randoms with the (non-TOF) ACFs.

Fixes #38 
Fixes #39 