### PR TITLE
another TOF swap fix

### DIFF
--- a/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
+++ b/src/buildblock/ProjDataInfoCylindricalNoArcCorr.cxx
@@ -501,6 +501,7 @@ find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<floa
     get_scanner_ptr()->get_num_detectors_per_ring();
 
   int d1, d2, r1, r2;
+  int tpos = timing_pos_num;
 
   this->initialise_det1det2_to_uncompressed_view_tangpos_if_not_done_yet();
 
@@ -510,6 +511,7 @@ find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<floa
       d2 = det1;
       r1 = Ring_B;
       r2 = Ring_A;
+      tpos *= -1;
   }
   else
   {
@@ -547,7 +549,7 @@ find_cartesian_coordinates_given_scanner_coordinates (CartesianCoordinate3D<floa
   coord_2 = lor.p2();
   
 #endif
-  if (timing_pos_num < 0)
+  if (tpos < 0)
     std::swap(coord_1, coord_2);
 }
 

--- a/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
@@ -60,7 +60,7 @@ CListEventScannerWithDiscreteDetectors<ProjDataInfoT>::
 get_LOR() const
 {
   LORAs2Points<float> lor;
-  const bool swap = this->get_delta_time() < 0.F;
+  const bool swap = true;// this->get_delta_time() < 0.F;
   // provide somewhat shorter names for the 2 coordinates, taking swap into account
   CartesianCoordinate3D<float>& coord_1 = swap ? lor.p2() : lor.p1();
   CartesianCoordinate3D<float>& coord_2 = swap ? lor.p1() : lor.p2();

--- a/src/test/test_time_of_flight.cxx
+++ b/src/test/test_time_of_flight.cxx
@@ -310,12 +310,12 @@ void TOF_Tests::test_CListEventROOT()
       if (det_pos_swapped.timing_pos() == det_pos.timing_pos())
         {
           check_if_equal(det_pos_swapped.pos1(), det_pos.pos1(), "CListEventROOT: get_detection_position with swapped detectors: equal timing_pos, but different pos1");
-                    check_if_equal(det_pos_swapped.pos1(), det_pos.pos1(), "CListEventROOT: get_detection_position with swapped detectors: equal timing_pos, but different pos1");
+          check_if_equal(det_pos_swapped.pos2(), det_pos.pos2(), "CListEventROOT: get_detection_position with swapped detectors: equal timing_pos, but different pos2");
         }
       else if (det_pos_swapped.timing_pos() == -det_pos.timing_pos())
         {
-          check_if_equal(det_pos_swapped.pos2(), det_pos.pos1(), "CListEventROOT: get_detection_position with swapped detectors: equal timing_pos, but different pos1");
-                    check_if_equal(det_pos_swapped.pos2(), det_pos.pos1(), "CListEventROOT: get_detection_position with swapped detectors: equal timing_pos, but different pos1");
+          check_if_equal(det_pos_swapped.pos2(), det_pos.pos1(), "CListEventROOT: get_detection_position with swapped detectors: opposite timing_pos, but different pos1/2");
+          check_if_equal(det_pos_swapped.pos1(), det_pos.pos2(), "CListEventROOT: get_detection_position with swapped detectors: opposite timing_pos, but different pos1/2");
         }
       else
         {


### PR DESCRIPTION
This fix is a more logical implementation of `find_cartesian_coordinates_given_scanner_coordinates` (discussed with @danieldeidda), and then a compensation in the listmode side. This makes `test_time_of_flight` and `test_proj_data_info` work, just like the previous code.

I am not really sure about the dependence on `timing_pos` in this function though. It doesn't seem to make a lot of sense, but the underlying problem is really that this is a non-TOF function that we tried to get to work for the TOF code.

In any case, we need to expand `test_proj_data_info` to test TOF bin swaps.
