### PR TITLE
revert  CListEventScannerWithDiscreteDetector constructor to master

### DIFF
--- a/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.h
+++ b/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.h
@@ -37,7 +37,7 @@ class CListEventScannerWithDiscreteDetectors : public CListEvent
 {
 public:
 
-  explicit CListEventScannerWithDiscreteDetectors(const shared_ptr<const ProjDataInfo>& proj_data_info);
+  explicit CListEventScannerWithDiscreteDetectors(const shared_ptr<Scanner>&);
 
   const Scanner * get_scanner_ptr() const
     { return this->uncompressed_proj_data_info_sptr->get_scanner_ptr(); }
@@ -78,7 +78,7 @@ public:
        return uncompressed_proj_data_info_sptr;
      }
 
-   //shared_ptr<Scanner> scanner_sptr;
+   shared_ptr<Scanner> scanner_sptr;
 
  private:
    shared_ptr<const ProjDataInfoT>

--- a/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
@@ -29,14 +29,14 @@ START_NAMESPACE_STIR
 
 template <class ProjDataInfoT>
 CListEventScannerWithDiscreteDetectors<ProjDataInfoT>::
-CListEventScannerWithDiscreteDetectors(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr)
+CListEventScannerWithDiscreteDetectors(const shared_ptr<Scanner>& scanner_sptr_v)
 {
   if (!proj_data_info_sptr)
     error("CListEventScannerWithDiscreteDetectors constructor called with zero pointer");
 
-  this->uncompressed_proj_data_info_sptr = std::dynamic_pointer_cast< const ProjDataInfoT >(proj_data_info_sptr->create_shared_clone());
+//  this->uncompressed_proj_data_info_sptr = std::dynamic_pointer_cast< const ProjDataInfoT >(proj_data_info_sptr->create_shared_clone());
 
-#if 0 // TODO: actually create uncompressed.
+//#if 0 // TODO: actually create uncompressed.
   this->scanner_sptr = scanner_sptr_v;
   auto pdi_ptr =
      ProjDataInfo::ProjDataInfoCTI(scanner_sptr_v, 
@@ -52,7 +52,7 @@ CListEventScannerWithDiscreteDetectors(const shared_ptr<const ProjDataInfo>& pro
       error("CListEventScannerWithDiscreteDetectors constructor called with scanner that gives wrong type of ProjDataInfo");
     }
   this->uncompressed_proj_data_info_sptr.reset(pdi_ptr_cast);
-#endif
+//#endif
 }
 
 template <class ProjDataInfoT>

--- a/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
+++ b/src/include/stir/listmode/CListEventScannerWithDiscreteDetectors.inl
@@ -31,8 +31,8 @@ template <class ProjDataInfoT>
 CListEventScannerWithDiscreteDetectors<ProjDataInfoT>::
 CListEventScannerWithDiscreteDetectors(const shared_ptr<Scanner>& scanner_sptr_v)
 {
-  if (!proj_data_info_sptr)
-    error("CListEventScannerWithDiscreteDetectors constructor called with zero pointer");
+  if (!scanner_sptr_v)
+      error("CListEventScannerWithDiscreteDetectors constructor called with zero scanner pointer");
 
 //  this->uncompressed_proj_data_info_sptr = std::dynamic_pointer_cast< const ProjDataInfoT >(proj_data_info_sptr->create_shared_clone());
 
@@ -40,9 +40,9 @@ CListEventScannerWithDiscreteDetectors(const shared_ptr<Scanner>& scanner_sptr_v
   this->scanner_sptr = scanner_sptr_v;
   auto pdi_ptr =
      ProjDataInfo::ProjDataInfoCTI(scanner_sptr_v, 
-                                   1, scanner_sptr->get_num_rings()-1,
-                                   scanner_sptr->get_num_detectors_per_ring()/2,
-                                   scanner_sptr->get_max_num_non_arccorrected_bins(),
+                                   1, this->scanner_sptr->get_num_rings()-1,
+                                   this->scanner_sptr->get_num_detectors_per_ring()/2,
+                                   this->scanner_sptr->get_max_num_non_arccorrected_bins(),
                                    false);
   auto pdi_ptr_cast =
     dynamic_cast<ProjDataInfoT *>(pdi_ptr);

--- a/src/include/stir/listmode/CListRecordGEHDF5.h
+++ b/src/include/stir/listmode/CListRecordGEHDF5.h
@@ -201,7 +201,7 @@ class CListRecordGEHDF5 : public CListRecord, public ListTime, // public CListGa
     get_time_in_millisecs() should therefore be zero at the first time stamp.
   */
  CListRecordGEHDF5(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr, const unsigned long first_time_stamp) :
-   CListEventCylindricalScannerWithDiscreteDetectors(proj_data_info_sptr),
+   CListEventCylindricalScannerWithDiscreteDetectors(this->scanner_sptr),
     first_time_stamp(first_time_stamp)
     {}
 

--- a/src/listmode_buildblock/CListRecordECAT8_32bit.cxx
+++ b/src/listmode_buildblock/CListRecordECAT8_32bit.cxx
@@ -28,7 +28,7 @@ namespace ecat {
 
 CListEventECAT8_32bit::
 CListEventECAT8_32bit(const shared_ptr<const ProjDataInfo>& proj_data_info_sptr) :
-  CListEventCylindricalScannerWithDiscreteDetectors(proj_data_info_sptr)
+    CListEventCylindricalScannerWithDiscreteDetectors(shared_ptr<Scanner>(new Scanner(*proj_data_info_sptr->get_scanner_ptr())))
 {
   const ProjDataInfoCylindricalNoArcCorr * const proj_data_info_ptr =
     dynamic_cast<const ProjDataInfoCylindricalNoArcCorr * const>(proj_data_info_sptr.get());


### PR DESCRIPTION
reverting CListEventScannerWithDiscreteDetectors<ProjDataInfoT>::
CListEventScannerWithDiscreteDetectors() to use projdata info