### PR TITLE
changed TOF-related interfile keywords

### DIFF
--- a/documentation/STIR-glossary.tex
+++ b/documentation/STIR-glossary.tex
@@ -14,7 +14,7 @@
 \end{center}
 
 \begin{center}
-\textit{Version 3.0}\\
+\textit{Version 6.0}\\
 Originally based on PARAPET Deliverable 4.1,
 Extended for Quantitative Reconstruction and motion compensation
 
@@ -30,35 +30,47 @@ medicine community uses the same words. In addition, it also gives a brief overv
 of data concepts. However, this is all kept brief. Please read additional material, for instance
 [Fah2002].
 
+Most of specifics of this document related to PET scanners, but a lot of terminology has clear
+correspondence for SPECT. However, most SPECT scanners rotate one or more gamma cameras around
+the patient, as opposed to have a ring of detectors.
+
 \section*{Basics}
 
 \begin{description}
-% ROW 2
+
 \item[Geometry] 
 A cylindrical geometry has been chosen to describe positron 
 tomographs made of a number of adjacent detector rings and reconstructed 
 image volumes. The geometry supports consequently two principal 
 directions \textit{axially} along the scanner cylinder and \textit{transaxially} 
 perpendicular to the cylinder axis.
-% ROW 3
+
 \item[Scanner] 
 Geometrically associated to the cylindrical volume defined by 
 the inner dimensions of the positron tomograph.
-% ROW 4
+
 \item[Detector ring ] 
 Geometrically associated to the cylindrical volume defined by 
 the dimensions of a detector ring. Note that because currently 
 Depth of Interaction is not taken into account, the effective ring radius 
 used in the building blocks is the sum of the inner ring radius 
 and an average depth of interaction (e.g. \ensuremath{\sim} 1cm for BGO).
-% ROW 5
+
 \item[Detector] 
 Sometimes called \textbf{detector crystal}. Geometrically associated 
 to the inner face of a detector element. The \textbf{scanner} is then 
 considered as a tessellation of \textbf{detectors} constructing adjacent \textbf{rings}. 
 For many scanners, detectors are organized in a block. For instance, 
-on the HR+ scanner, a detector block consists of 8x8 detectors.
-% ROW 6
+on the HR+ scanner, a detector block consists of 8x8 detectors. Current scanners
+have mini-blocks, related to the read-out.
+Blocks are often organised in \textbf{modules}, currently called \textbf{buckets} in STIR.
+
+\item[Time of Flight (TOF) for PET]
+Many modern PET scanners measure the difference in arrival time of the 2 gamma photons with
+a certain \textbf{TOF timing resolution} (often expressed in ps). In current scanners,
+the TOF information is discretised into \textbf{TOF bins}.
+
+
 \item[LOR (Line-Of-Response)] 
 Line joining the centres of two \textbf{detectors}. Ignoring scatter, 
 attenuation and other physical effects, the average number of 
@@ -69,12 +81,13 @@ nor scatter within the detectors. It can be shown that this line
 integral approximation works best for LORs that do not run parallel 
 to edges within the object. We say that the projector that uses 
 this model is a \textbf{ray tracing} projector.
-% ROW 7
+
 \item[TOR (Tube of response)] 
 Tube joining two \textbf{detectors}. 
-% ROW 8
+
 \item[Sinogram] 
-Set of \textbf{bins} corresponding to 1 segment and 1 \textbf{axial} position. 
+Set of \textbf{bins} corresponding to 1 \textbf{segment} and 1 \textbf{axial} position and (in STIR)
+1 TOF bin.
 Before \textbf{axial compression,} this corresponds to LORs in a \textbf{detector} \textbf{ring} 
 (\textit{direct} \textit{sinogram}) or between two different \textbf{detector} \textbf{rings} 
 (\textit{oblique} \textit{sinogram}). For a \textbf{scanner} of $n$ \textbf{detector 
@@ -83,26 +96,33 @@ sinograms} for a total of $n^2$ \textbf{sinograms}. With \textbf{axial
 compression}, the number of \textbf{direct sinograms} is $2n-1$. Conventionally, 
 the \textbf{view} angle in an oblique sinogram runs only over 180 
 degrees, meaning that only half of the detectors in each ring 
-are covered. The other half corresponds to the \textbf{sinogram} in 
-the opposite \textbf{segment} (with minus the average ring difference),
-% ROW 9
+are covered\footnote{In SPECT, rotations often cover 360 degrees.}.
+The other half corresponds to the \textbf{sinogram} in 
+the opposite \textbf{segment} (with minus the average ring difference).
+
+In PET, the number of tangential positions determines the ``fan-size''. Its maximum is
+equal to the number of detectors per ring. Scanners use far less
+you don’t want to look at coincidences between neighbouring crystals!).
+
 \item[View] 
 The azimuthal angle of an \textbf{LOR} (ignoring \textbf{interleaving}, 
-see the documentation of the ProjDataInfoCylindricalNoArcCorr 
-class, and \textbf{mashing}).
-% ROW 10
+see the documentation of the \texttt{ProjDataInfoCylindricalNoArcCorr}
+class).
+The maximum number of views is half the number of detectors per ring
+(this is again due to interleaving).
+
 \item[Bin] 
 A single element in a sinogram, completely specified by its \textbf{segment, 
-axial} \textbf{position, view} and \textbf{tangential position}.
-% ROW 11
-\item[Ring difference] 
+axial} \textbf{position, view}, \textbf{tangential position} and (in PET) \textbf{TOF bin}.
+
+\item[Ring difference (in PET)] 
 Number of \textbf{rings} between two \textbf{rings} associated to a \textbf{sinogram}. 
 If \textit{ringA} and \textit{ringB} are the ring numbers, the \textbf{ring 
 difference} is given by \textit{ringB} -- \textit{ringA}. Thus there can be \textit{positive} 
-and \textit{negative} \textbf{ring differences}. \linebreak
+and \textit{negative} \textbf{ring differences}.\\
 The (average) \textbf{ring difference} of a \textbf{direct sinogram} is 
 zero.
-% ROW 12
+
 \item[Michelogram] 
 Representation of \textbf{sinograms} on a square grid as shown in 
 Annex 1. If \textit{ringA} and \textit{ringB} are the ring numbers associated 
@@ -110,14 +130,14 @@ to a \textbf{sinogram}, \textit{ringA} is represented on the horizontal
 axis and \textit{ringB} on the vertical axis. \textbf{Positive ring differences} 
 are below the line representing \textbf{direct sinograms} and \textbf{negative 
 ring differences} above this line.
-% ROW 13
+
 \item[Segment] 
 Set of \textbf{merged} \textbf{sinograms} with a common average \textbf{ring 
 difference} as shown in Annex 1.
-% ROW 14
+
 \item[Viewgram] 
 Set of equal azimuth \textbf{merged} \textbf{LORs} of a \textbf{segment}.
-% ROW 15
+
 \item[Projection data]
 The set of all (measured) LORs, normally split into \textbf{segments} etc.
 The word ``projection'' is used because after various corrections and
@@ -129,38 +149,38 @@ least 1 \textbf{bin} with non-zero detection probability\textbf{.} In many
 cases, the term is also used for the smaller volume for which 
 there is at least 1 \textbf{bin} with non-zero detection probability 
 for every \textbf{view}. The latter FOV is usually cylindrical.
-% ROW 16
+
 \item[Image slice] 
 Geometrically associated to a cylindrical volume defined by 
 a slice of the \textbf{FOV}. By convention, a \textbf{slice} is half the 
 width of a \textbf{ring}. For a \textbf{scanner} of \textit{n} \textbf{detector} \textbf{rings}, 
 there are 2\textit{n}--1 \textbf{image slices}.
-% ROW 17
+
 \item[Direct plane] 
 \textbf{Image slice} centered on a \textbf{ring}. For a \textbf{scanner} of \textit{n} \textbf{detector} \textbf{rings}, 
 there are \textit{n} \textbf{direct planes}. The \textbf{FOV} is ended by two \textbf{direct 
 planes} centered on the first and last \textbf{rings}.
-% ROW 18
+
 \item[Cross plane] 
 \textbf{Image slice} in between two consecutive \textbf{direct planes}. \textbf{Direct 
 planes} are adjacent to \textbf{cross planes}. For a \textbf{scanner} of \textit{n} \textbf{detector} \textbf{rings}, 
 there are 2\textit{n}--1 \textbf{cross planes}.
 \end{description}
 
-\section*{Different data compressions used in PET data}
+\section*{Different (lossy) data compressions used}
 \begin{description}
-% ROW 21
+
 \item[Trimming] 
 Reduction of the number of \textbf{bins} in tangential direction without 
 changing the size of \textbf{bins}. \textbf{Trimming} is a type of \textbf{bin} 
 truncation.
-% ROW 22
-\item[Angular compression (Mashing)] 
+
+\item[Angular compression (view mashing)] 
 Reduction of the number of \textbf{views} by a multiple of two. As 
 an example, doing a \textbf{mashing} of 2 means that pairs of \textbf{views} 
 have been added 2 by 2 to form only one \textbf{view}.
-% ROW 23
-\item[Axial compression (Span)] 
+
+\item[Axial compression (Span), PET] 
 Reduction of the number of \textbf{sinograms} at different \textbf{ring 
 differences} as shown in Annex 1. \textbf{Span} is a number used by 
 Siemens/CTI to say how much axial compression has been used. 
@@ -173,57 +193,75 @@ In \textbf{STIR}, we call this \textit{span 2}. As a generalisation,
 \textbf{STIR} supports any even span (where segment $0$ has effective
 $\mathrm{span}+1$).
 Finally, for historical reasons \textbf{STIR} also support a different mixed
-format where segment $0$ has span $3$ but higher segments have span $1$.
+format where segment $0$ has span $3$ but higher segments have span $1$,
+or indeed any mix ``spans-per-segment''.
+
+\item[SSRB]
+Originally, single slice rebinning was developed to collapse 3D PET data into non-oblique sinograms.
+In STIR, it is generalised to combine segments, optionally keeping some oblique segments.
+this effectively increases the \textbf{span}.
+
+\item[TOF mashing (PET)]
+Reduction of the number of \textbf{TOF bins} by combining adjacent bins. The \textbf{TOF mashing factor}
+is defined as the ratio of the \textbf{Maximum number of (unmashed) TOF time bins} supported
+by the scanner (in list-mode) over the actual number of TOF bins. Currently in STIR, this
+ratio has to be an integer. The size of a TOF bin is computed by multiplying the
+\textbf{TOF mashing factor} with the \textbf{size of unmashed TOF time bins}, with the latter
+defined as a scanner property.\\
+Note that many PET scanners use a \textbf{TOF mashing factor} greater than 1
+for their standard histogrammed projection data.
+
 \end{description}
 
 \section*{Terms used in quantitative PET reconstruction}
 \begin{description}
-% ROW 24
+
 \item[Scatter Point]
 Coordinate where a scatter event takes place. 
-% ROW 25
+
 \item[SSS - Single scatter simulation]
 Estimation of the probability to measure a coincidence event that one of
 the two photons has been scattered only once. 
-% ROW 26
+
 \item[B-Splines]
 Basis splines are a set of polynomial functions that have minimal support with 
 respect to a given degree, smoothness, and domain partition. In imaging they 
 are useful for performing very fast multidimensional interpolation calculations.
-% ROW 27
+
+
 \item[Inverse-SSRB]
 It is the pseudo-inverse operation of single slice rebinning which can be used 
 as the simplest way to extrapolate direct sinograms into indirect sinograms. 
-% ROW 28
+
 \item[Plasma Data]
 Radioactivity concentration in plasma (and blood) during the scanning acquisition.
 Usually it is measured in $\mathit{kBq/cm^3}$ over a time window of 1 second. 
-% ROW 29
+
 \item[Dynamic Data/Images]
 A stack of projection data or images through time.
-% ROW 30
+
 \item[Kinetic Model]
 The kinetic model describe the tracer exchange between plasma and tissue 
 and between tissue compartments.
-% ROW 31
+
 \item[Kinetic Parameters]
 The parameters of the kinetic model which are estimated such that 
 the model is in agreement with the acquired data. 
-% ROW 32
+
 \item[(Kinetic) Model Matrix]
 Linear kinetic models can be written with compact matrix operations, which 
 relate the dynamic images and the kinetic parameters with the kinetic model matrix. 
 This matrix can be seen as the application of the transformation from parametric 
 domain to the temporal domain. 
-% ROW 33
+
 \item[Patlak Plot]
 For irreversible tracers, after a certain period from tracer injection, 
 the free tracer in tissue reaches equilibrium with the radiotracer in plasma and 
 then the original model simplifies to a linear plot known as the Patlak Plot.
-% ROW 34
+
 \item[Parametric Image]
 An image whose voxels hold the values the kinetic parameters.
-% ROW 35
+
 \item[Parametric Image Reconstruction (PIR)]
 Estimation of the kinetic parameters from dynamic images for each voxel (indirect PIR). 
 The parametric images can also be reconstructed directly from dynamic projection data. 
@@ -262,8 +300,8 @@ In the drawing below, the diagonal
 lines connecting the dots indicate the sinograms that are added 
 together. The illustration is for \textbf{span} 7=4+3 (this terminology 
 was introduced because for some axial positions, 4 sinograms 
-are added, while for others only 3. Note that \textbf{span} is always 
-odd.).
+are added, while for others only 3. Note that for even \textbf{span}, segment 0
+has one more set of axial positions added than the oblique ones.).
 
 
 \begin{figure}[htbp]

--- a/documentation/release_notes_TOF.htm
+++ b/documentation/release_notes_TOF.htm
@@ -50,8 +50,9 @@ improvements to the documentation.
 
 <h3>New functionality</h3>
 <ul>
-<li>projectors now have a <code>clone()</code> member, currently returning a bare pointer (like other STIR classes)
-</li>
+  <li>
+    projectors now have a <code>clone()</code> member, currently returning a bare pointer (like other STIR classes)
+  </li>
 </ul>
 
 
@@ -125,6 +126,10 @@ from the above):</H2>
 <ul>
   <li><code>Bin</code> can now be output to stream as text</li>
   <li>added <code>RunTests::check_if_equal</code> for <code>Bin</code></li>
+  <li>
+    <code>KeyParser</code> has a new facility to add an alias to a keyword. This can be used to rename a keyword
+    for instance while remaining backwards compatible. By default, a warning will be written, but this can be disabled.
+  </li>
 </ul>
 
 

--- a/src/IO/InterfileHeader.cxx
+++ b/src/IO/InterfileHeader.cxx
@@ -546,7 +546,14 @@ InterfilePDFSHeader::InterfilePDFSHeader()
     (KeywordProcessor)&InterfilePDFSHeader::resize_segments_and_set, 
     &max_ring_difference);
   
-  
+  tof_mash_factor = 1;
+  add_key("TOF mashing factor",
+          &tof_mash_factor);
+#if STIR_VERSION < 070000
+  add_alias_key("TOF mashing factor", "%TOF mashing factor");
+#endif
+
+  // Scanner keys
   // warning these keys should match what is in Scanner::parameter_info()
   // TODO get Scanner to parse these
   ignore_key("Scanner parameters");
@@ -615,15 +622,18 @@ InterfilePDFSHeader::InterfilePDFSHeader()
   add_key("Reference energy (in keV)",
           &reference_energy);
 
-  tof_mash_factor = 1;
-  add_key("%TOF mashing factor",
-          &tof_mash_factor);
   max_num_timing_poss = -1;
-  add_key("Number of TOF time bins",
+  add_key("Maximum number of (unmashed) TOF time bins",
           &max_num_timing_poss);
+#if STIR_VERSION < 070000
+  add_alias_key("Maximum number of (unmashed) TOF time bins", "Number of TOF time bins");
+#endif
   size_of_timing_pos = -1.f;
-  add_key("Size of timing bin (ps)",
+  add_key("Size of unmashed TOF time bins (ps)",
           &size_of_timing_pos);
+#if STIR_VERSION < 070000
+  add_alias_key("Size of unmashed TOF time bins (ps)", "Size of timing bin (ps)");
+#endif
   timing_resolution = -1.f;
   add_key("Timing resolution (ps)",
           &timing_resolution);

--- a/src/buildblock/KeyParser.cxx
+++ b/src/buildblock/KeyParser.cxx
@@ -2,7 +2,7 @@
     Copyright (C) 2000 PARAPET partners
     Copyright (C) 2000 - 2009-04-30, Hammersmith Imanet Ltd
     Copyright (C) 2011-07-01 - 2012-01-29, Kris Thielemans
-    Copyright (C) 2020, 2021 University College London
+    Copyright (C) 2020, 2021, 2023, 2024 University College London
     This file is part of STIR.
 
     SPDX-License-Identifier: Apache-2.0 AND License-ref-PARAPET-license
@@ -30,20 +30,13 @@
 #include "stir/error.h"
 #include <typeinfo>
 #include <fstream>
+#include <sstream>
 #include <cstring>
 #include <cstdlib>
 #include "stir/warning.h"
-# ifdef BOOST_NO_STDC_NAMESPACE
- namespace std { using ::getenv; }
-# endif
-
 #include <strstream>
-
-#ifndef BOOST_NO_STRINGSTREAM
 #include <sstream>
-#endif
 
-#ifndef STIR_NO_NAMESPACES
 using std::ifstream;
 using std::cerr;
 using std::cout;
@@ -58,7 +51,6 @@ using std::list;
 using std::pair;
 using std::istream;
 using std::ostream;
-#endif
 
 START_NAMESPACE_STIR
 
@@ -274,6 +266,12 @@ bool KeyParser::parse(const char * const filename, const bool write_warning)
       return false;
     }
    return parse(hdr_stream, write_warning);
+}
+
+bool KeyParser::parse(const std::string& s, const bool write_warning)
+{
+  std::stringstream hdr_stream(s);
+  return parse(hdr_stream, write_warning);
 }
 
 bool KeyParser::parse(istream& f, const bool write_warning)
@@ -564,6 +562,15 @@ void KeyParser::add_key(const string& keyword,
   add_in_keymap(keyword, map_element(t, &KeyParser::set_variable, variable, vectorised_key_level, list_of_values));
 }
 
+void KeyParser::add_alias_key(const std::string& keyword, const std::string& alias, bool deprecated_key)
+{
+  const auto std_alias = standardise_keyword(alias);
+  const auto std_kw = standardise_keyword(keyword);
+  if (deprecated_key)
+    this->deprecated_alias_map[std_alias] = std_kw;
+  else
+    this->alias_map[std_alias] = std_kw;
+}
 
 void
 KeyParser::print_keywords_to_stream(ostream& out) const
@@ -623,6 +630,30 @@ Succeeded KeyParser::parse_header(const bool write_warning)
   
 }	
 
+std::string KeyParser::resolve_alias(const std::string& kw) const
+{
+  // search in alias_map
+  {
+    auto iter = alias_map.find(kw);
+    if (iter != alias_map.end())
+      {
+        return iter->second;
+      }
+  }
+  // search in deprecated_alias_map
+  {
+    auto iter = deprecated_alias_map.find(kw);
+    if (iter != deprecated_alias_map.end())
+      {
+        warning("KeyParser: found deprecated keyword '" + kw + "'. Replace with '" + iter->second
+                + "' to disable this warning and for future compatibility.");
+        return iter->second;
+      }
+  }
+  // not found: return original
+  return kw;
+}
+
 Succeeded KeyParser::read_and_parse_line(const bool write_warning)
 {
   string line;  
@@ -647,7 +678,7 @@ Succeeded KeyParser::read_and_parse_line(const bool write_warning)
     }
 
   // gets keyword
-  keyword=standardise_keyword(get_keyword(line));
+  keyword=resolve_alias(standardise_keyword(get_keyword(line)));
   return parse_value_in_line(line, write_warning);
 }
 

--- a/src/buildblock/Scanner.cxx
+++ b/src/buildblock/Scanner.cxx
@@ -1061,9 +1061,9 @@ initialise_max_FOV_radius() {
   {
     // for other geometries, loop through all detectors and set the radius to the largest found distance
     max_FOV_radius = inner_ring_radius;
-    for (auto tangential_pos = 0; tangential_pos < detector_map_sptr->get_num_tangential_coords(); tangential_pos++)
-      for (auto axial_pos = 0; axial_pos < detector_map_sptr->get_num_axial_coords(); axial_pos++)
-        for (auto radial_pos = 0; radial_pos < detector_map_sptr->get_num_radial_coords(); radial_pos++)
+    for (auto tangential_pos = 0U; tangential_pos < detector_map_sptr->get_num_tangential_coords(); tangential_pos++)
+      for (auto axial_pos = 0U; axial_pos < detector_map_sptr->get_num_axial_coords(); axial_pos++)
+        for (auto radial_pos = 0U; radial_pos < detector_map_sptr->get_num_radial_coords(); radial_pos++)
     {
       auto coord = detector_map_sptr->get_coordinate_for_det_pos(stir::DetectionPosition<>(tangential_pos, axial_pos, radial_pos));
       const auto detector_radius = sqrt(coord.x() * coord.x() + coord.y() * coord.y()) - average_depth_of_interaction;
@@ -1402,13 +1402,7 @@ string
 Scanner::parameter_info() const
 {
   // warning: these should match the parsing keywords in InterfilePDFSHeader
-#ifdef BOOST_NO_STRINGSTREAM
-  // dangerous for out-of-range, but 'old-style' ostrstream seems to need this
-  char str[10000];
-  ostrstream s(str, 10000);
-#else
   std::ostringstream s;
-#endif
   s << "Scanner parameters:= "<<'\n';
 
   s << "Scanner type := " << get_name() <<'\n';
@@ -1433,8 +1427,8 @@ Scanner::parameter_info() const
 
   if (is_tof_ready())
   {
-    s << "Number of TOF time bins :=" << get_max_num_timing_poss() << "\n";
-    s << "Size of timing bin (ps) :=" << get_size_of_timing_pos() << "\n";
+    s << "Maximum number of (unmashed) TOF time bins :=" << get_max_num_timing_poss() << "\n";
+    s << "Size of unmashed TOF time bins (ps) :=" << get_size_of_timing_pos() << "\n";
     s << "Timing resolution (ps) :=" << get_timing_resolution() << "\n";
   }
 

--- a/src/include/stir/listmode/CListModeDataROOT.h
+++ b/src/include/stir/listmode/CListModeDataROOT.h
@@ -149,12 +149,14 @@ private:
     //! Pointer to the listmode data
     shared_ptr<InputStreamFromROOTFile > root_file_sptr;
 
-//! \name Variables that can be set in the hroot file to define a scanner's geometry.
+//! \name Variables that can be set in the hroot file to define a scanner's geometry etc.
 //! They are compared to the Scanner  (if set)  and the InputStreamFromROOTFile
 //! geometry, as given by the repeaters. Can be used to check for inconsistencies.
 //@{
     //! The name of the originating scanner
     std::string originating_system;
+    //! \name Geometry
+    //@{
     //! Number of rings, set in the hroot file (optional)
     int num_rings;
     //! Number of detectors per ring, set in the hroot file (optional)
@@ -173,19 +175,30 @@ private:
     float ring_spacing;
     //! Bin size, set in the hroot file (optional)
     float bin_size;
+    //@}
 
+    //! \name TOF information
+    /*! These describe the maximum capabilities of the scanner, i.e. in 
+      list-mode data, even if vendors often never construct sinogram with
+      this TOF resolution.
+    */
+    //@{
     int max_num_timing_bins;
 
     float size_timing_bin;
 
     float timing_resolution;
 
+    int tof_mash_factor;
+    //@}
+
+    //! \name energy information
+    //@{
     float energy_resolution;
 
     float reference_energy;
-//@}
-
-    int tof_mash_factor;
+   //@}
+   //@}
 
     KeyParser parser;
 

--- a/src/test/test_KeyParser.cxx
+++ b/src/test/test_KeyParser.cxx
@@ -1,7 +1,7 @@
 //
 //
 /*
-    Copyright (C) 2020, University College London
+    Copyright (C) 2020, 2024, University College London
     This file is part of STIR.
  
     SPDX-License-Identifier: Apache-2.0
@@ -21,6 +21,8 @@
 #include "stir/KeyParser.h"
 
 #include <sstream>
+#include <vector>
+#include <algorithm>
 #include "stir/RunTests.h"
 
 START_NAMESPACE_STIR
@@ -37,10 +39,19 @@ public:
     add_start_key("start");
     add_stop_key("stop");
     add_key("scalar", &scalar_v);
+    add_alias_key("scalar", "new alias", false);
+    add_alias_key("scalar", "deprecated alias", true);
+    add_alias_key("vector", "new vector alias", false);
+    add_alias_key("vector", "deprecated vector alias", true);
     add_vectorised_key("vector", &vector_v);
   }
   elemT scalar_v;
   std::vector<elemT> vector_v;
+  bool operator==(TestKP& other) const
+  {
+    return scalar_v == other.scalar_v &&
+      std::equal(vector_v.begin(),vector_v.end(), other.vector_v.begin());
+  }
 };
 
 /*!
@@ -59,13 +70,13 @@ void
 KeyParserTests::run_tests()
 {
   std::cerr << "Tests for KeyParser\n";
-  std::cerr << "... int parsing\n";
+  std::cerr << "\n..... int parsing\n";
   run_tests_one_type<int>();
-  std::cerr << "... unsigned int parsing\n";
+  std::cerr << "\n..... unsigned int parsing\n";
   run_tests_one_type<unsigned int>();
-  std::cerr << "... float parsing\n";
+  std::cerr << "\n..... float parsing\n";
   run_tests_one_type<float>();
-  std::cerr << "... double parsing\n";
+  std::cerr << "\n..... double parsing\n";
   run_tests_one_type<double>();
 }
 
@@ -73,21 +84,54 @@ template <typename elemT>
 void
 KeyParserTests::run_tests_one_type()
 {
-
-  TestKP<elemT>  parser;
   // basic test if parsing ok
   {
+    TestKP<elemT>  parser;
+    TestKP<elemT>  parser2;
     std::stringstream str;
     str << "start:=\n"
         << "scalar:=2\n"
         << "vector[1] := 3\n"
         << "stop     :=\n";
     parser.parse(str);
-    check_if_equal(parser.scalar_v, static_cast<elemT>(2), "parsing int");
-    check_if_equal(parser.vector_v[0], static_cast<elemT>(3), "parsing int vector");
+    check_if_equal(parser.scalar_v, static_cast<elemT>(2), "parsing scalar");
+    check_if_equal(parser.vector_v[0], static_cast<elemT>(3), "parsing vector");
+    parser2.parse(parser.parameter_info());
+    check(parser == parser2, "check parsing of parameter_info()");
+  }
+  // test alias
+  {
+    TestKP<elemT>  parser;
+    TestKP<elemT>  parser2;
+    std::stringstream str;
+    str << "start:=\n"
+        << "new alias:=2\n"
+        << "new vector alias[1] := 3\n"
+        << "stop     :=\n";
+    parser.parse(str);
+    check_if_equal(parser.scalar_v, static_cast<elemT>(2), "parsing scalar with alias");
+    check_if_equal(parser.vector_v[0], static_cast<elemT>(3), "parsing vector with alias");
+    check(parser.parameter_info().find("alias") == std::string::npos, "check alias is not in parameter_info()");
+    // check if parsing back parameter_info() gives same results
+    parser2.parse(parser.parameter_info());
+    check(parser == parser2, "check parsing of parameter_info() with alias");
+
+    // same with deprecated alias
+    std::cerr << "\nNext test should write warnings about deprecated alias\n";
+    str << "start:=\n"
+        << "deprecated alias:=3\n"
+        << "deprecated vector alias[1] := 4\n"
+        << "stop     :=\n";
+    parser.parse(str);
+    check_if_equal(parser.scalar_v, static_cast<elemT>(3), "parsing scalar with deprecated alias");
+    check_if_equal(parser.vector_v[0], static_cast<elemT>(4), "parsing vector with deprecated alias");
+    check(parser.parameter_info().find("alias") == std::string::npos, "check alias is not in parameter_info()");
+    parser2.parse(parser.parameter_info());
+    check(parser == parser2, "check parsing of parameter_info() with alias");
   }
   // test 1 if parsing catches errors
   {
+    TestKP<elemT>  parser;
     std::stringstream str;
     str << "start:=\n"
         << "scalar[1]:=2\n"
@@ -95,7 +139,7 @@ KeyParserTests::run_tests_one_type()
         << "stop     :=\n";
     try
       {
-        std::cerr <<  "Next test should write an error (but not crash!)"  << std::endl;
+        std::cerr <<  "\nNext test should write an error (but not crash!)"  << std::endl;
         parser.parse(str);
         check(false, "parsing non-vectorised key with vector should have failed");
       }
@@ -106,6 +150,7 @@ KeyParserTests::run_tests_one_type()
   }
   // test 2 if parsing catches errors
   {
+    TestKP<elemT>  parser;
     std::stringstream str;
     str << "start:=\n"
         << "scalar:=2\n"
@@ -113,7 +158,7 @@ KeyParserTests::run_tests_one_type()
         << "stop     :=\n";
     try
       {
-        std::cerr <<  "Next test should write an error (but not crash!)"  << std::endl;
+        std::cerr <<  "\nNext test should write an error (but not crash!)"  << std::endl;
         parser.parse(str);
         check(false, "parsing vectorised key with non-vector should have failed");
       }


### PR DESCRIPTION
use hopefully clearer names to avoid confusion when TOF mashing is used
    
- new: "TOF mashing factor", old: "%TOF mashing factor" (no need for % in Interfile. In the original standard, % was used to specify a required keyword, but people misunderstood, and in any case, "TOF mashing factor" is not required)
- new: "Maximum number of (unmashed) TOF time bins", old: "Number of TOF time bins"
- new: "Size of unmashed TOF time bins (ps)", old: "Size of timing bin (ps)"

Old keywords are entered as aliases until STIR 7.0 (which means a warning will be issued if you use them).

@danieldeidda, @nicolejurjew, @nikefth, @robbietuk, what do you think about these new names?
